### PR TITLE
Add Support for D Date/Time types in C#.

### DIFF
--- a/csharp/source/autowrap/csharp/Boilerplate.cs
+++ b/csharp/source/autowrap/csharp/Boilerplate.cs
@@ -85,6 +85,29 @@ namespace Autowrap {
         private slice _error;
     }
 
+    [GeneratedCodeAttribute("Autowrap", "1.0.0.0")]
+    internal static class DateTimeExtensions {
+        public static DateTime DateTimeFromSlice(slice wstring) {
+            var iso = SharedFunctions.SliceToString(slice, DStringType._wstring);
+            return DateTime.Parse(iso);
+        }
+
+        public static DateTimeOffset DateTimeOffsetFromSlice(slice wstring) {
+            var iso = SharedFunctions.SliceToString(slice, DStringType._wstring);
+            return DateTimeOffset.Parse(iso);
+        }
+
+        public static slice ToSlice(this DateTime dateTime) {
+            var iso = dateTime.ToString("o");
+            return SharedFunctions.CreateWstring(iso);
+        }
+
+        public static slice ToSlice(this DateTimeOffset dateTime) {
+            var iso = dateTime.ToString("o");
+            return SharedFunctions.CreateWstring(iso);
+        }
+    }
+
 %3$s    [GeneratedCodeAttribute("Autowrap", "1.0.0.0")]
     public static class SharedFunctions {
         static SharedFunctions() {

--- a/csharp/source/autowrap/csharp/Boilerplate.cs
+++ b/csharp/source/autowrap/csharp/Boilerplate.cs
@@ -95,7 +95,7 @@ namespace Autowrap {
         public static implicit operator datetime(DateTime ret) { return new datetime(ret.Ticks, 0L); }
         public static implicit operator datetime(DateTimeOffset ret) { return new datetime(ret.Ticks, ret.Offset.Ticks); }
         public static implicit operator datetime(TimeSpan ret) { return new datetime(ret.Ticks, 0L); }
-        public static implicit operator DateTime(datetime ret) { return new DateTime(ret._ticks, DateTimeKind.Unspecified); }
+        public static implicit operator DateTime(datetime ret) { return new DateTime(ret._ticks, DateTimeKind.Local); }
         public static implicit operator DateTimeOffset(datetime ret) { return new DateTimeOffset(ret._ticks, new TimeSpan(ret._offset)); }
         public static implicit operator TimeSpan(datetime ret) { return new TimeSpan(ret._ticks); }
         private long _ticks;
@@ -121,7 +121,6 @@ namespace Autowrap {
         static SharedFunctions() {
             Stream stream = null;
             var outputName = Path.Combine(Environment.CurrentDirectory, RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "libcsharp-tests.dylib" : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "libcsharp-tests.so" : "csharp-tests.dll");
-            Console.WriteLine($"Library Path: {outputName}");
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
                 stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("%2$s.lib%1$s.dylib");

--- a/csharp/source/autowrap/csharp/Boilerplate.cs
+++ b/csharp/source/autowrap/csharp/Boilerplate.cs
@@ -86,26 +86,34 @@ namespace Autowrap {
     }
 
     [GeneratedCodeAttribute("Autowrap", "1.0.0.0")]
-    internal static class DateTimeExtensions {
-        public static DateTime DateTimeFromSlice(slice wstring) {
-            var iso = SharedFunctions.SliceToString(slice, DStringType._wstring);
-            return DateTime.Parse(iso);
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct datetime {
+        public datetime(long ticks, long offset) {
+            this._ticks = ticks;
+            this._offset = offset;
         }
+        public static implicit operator datetime(DateTime ret) { return new datetime(ret.Ticks, 0L); }
+        public static implicit operator datetime(DateTimeOffset ret) { return new datetime(ret.Ticks, ret.Offset.Ticks); }
+        public static implicit operator datetime(TimeSpan ret) { return new datetime(ret.Ticks, 0L); }
+        public static implicit operator DateTime(datetime ret) { return new DateTime(ret._ticks, DateTimeKind.Unspecified); }
+        public static implicit operator DateTimeOffset(datetime ret) { return new DateTimeOffset(ret._ticks, new TimeSpan(ret._offset)); }
+        public static implicit operator TimeSpan(datetime ret) { return new TimeSpan(ret._ticks); }
+        private long _ticks;
+        private long _offset;
+    }
 
-        public static DateTimeOffset DateTimeOffsetFromSlice(slice wstring) {
-            var iso = SharedFunctions.SliceToString(slice, DStringType._wstring);
-            return DateTimeOffset.Parse(iso);
+    [GeneratedCodeAttribute("Autowrap", "1.0.0.0")]
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct return_datetime_error {
+        private void EnsureValid() {
+            var errStr = SharedFunctions.SliceToString(_error, DStringType._wstring);
+            if (!string.IsNullOrEmpty(errStr)) throw new DLangException(errStr);
         }
-
-        public static slice ToSlice(this DateTime dateTime) {
-            var iso = dateTime.ToString("o");
-            return SharedFunctions.CreateWstring(iso);
-        }
-
-        public static slice ToSlice(this DateTimeOffset dateTime) {
-            var iso = dateTime.ToString("o");
-            return SharedFunctions.CreateWstring(iso);
-        }
+        public static implicit operator DateTime(return_datetime_error ret) { ret.EnsureValid(); return ret._value; }
+        public static implicit operator DateTimeOffset(return_datetime_error ret) { ret.EnsureValid(); return ret._value; }
+        public static implicit operator TimeSpan(return_datetime_error ret) { ret.EnsureValid(); return ret._value; }
+        private datetime _value;
+        private slice _error;
     }
 
 %3$s    [GeneratedCodeAttribute("Autowrap", "1.0.0.0")]

--- a/csharp/source/autowrap/csharp/boilerplate.d
+++ b/csharp/source/autowrap/csharp/boilerplate.d
@@ -16,8 +16,9 @@ import autowrap.csharp;
 
 import core.time;
 import core.memory;
-import std.datetime : DateTime, SysTime, Date, TimeOfDay, SimpleTimeZone, LocalTime;
 import std.conv;
+import std.datetime : DateTime, SysTime, Date, TimeOfDay, SimpleTimeZone, LocalTime;
+import std.meta : Unqual;
 import std.string;
 import std.traits;
 import std.utf;
@@ -109,17 +110,20 @@ if (isDateTimeType!T) {
     return value.map!datetime.array;
 }
 
-public T fromDatetime(T)(datetime value)
-if (isDateTimeType!T) {
-    static if (is(T == SysTime)) {
-        return SysTime(value.ticks, cast(immutable)new SimpleTimeZone(hnsecs(value.offset)));
-    } else static if (is(T == DateTime)) {
-        return cast(T)SysTime(value.ticks, LocalTime());
-    } else static if (is(T == Date) || is(T == TimeOfDay)) {
-        return cast(T)SysTime(value.ticks, cast(immutable)new SimpleTimeZone(hnsecs(0)));
-    } else static if (is(T == Duration)) {
-        return hnsecs(value.ticks);
-    }
+public T fromDatetime(T)(datetime value) if (is(Unqual!T == SysTime)) {
+    return SysTime(value.ticks, cast(immutable)new SimpleTimeZone(hnsecs(value.offset)));
+}
+
+public T fromDatetime(T)(datetime value) if (is(Unqual!T == DateTime)) {
+    return cast(T)SysTime(value.ticks, LocalTime());
+}
+
+public T fromDatetime(T)(datetime value) if (is(Unqual!T == Date) || is(Unqual!T == TimeOfDay)) {
+    return cast(T)SysTime(value.ticks, cast(immutable)new SimpleTimeZone(hnsecs(0)));
+}
+
+public T fromDatetime(T)(datetime value) if (is(Unqual!T == Duration)) {
+    return hnsecs(value.ticks);
 }
 
 public T[] fromDatetime1DArray(T)(datetime[] value)

--- a/csharp/source/autowrap/csharp/boilerplate.d
+++ b/csharp/source/autowrap/csharp/boilerplate.d
@@ -14,134 +14,140 @@ import autowrap.common;
 import autowrap.reflection;
 import autowrap.csharp;
 
-public struct OutputFileName {
-    string value;
+import core.time;
+import core.memory;
+import std.datetime : DateTime, SysTime, Date, TimeOfDay, SimpleTimeZone, LocalTime;
+import std.conv;
+import std.string;
+import std.traits;
+import std.utf;
+
+extern(C) export struct returnValue(T) {
+    T value;
+    wstring error;
+
+    this(T value) nothrow {
+        this.value = value;
+        static if (isArray!(T) || is(T == class) || is(T == interface)) {
+            if (this.value !is null) {
+                pinPointer(cast(void*)this.error.ptr);
+            }
+        }
+        this.error = null;
+    }
+
+    this(Exception error) nothrow {
+        this.value = T.init;
+        try {
+            this.error = to!wstring(error.toString());
+        } catch(Exception ex) {
+            this.error = "Unhandled Exception while marshalling exception data. You should never see this error.";
+        }
+        pinPointer(cast(void*)this.error.ptr);
+    }
+}
+
+extern(C) export struct returnVoid {
+    wstring error = null;
+
+    this(Exception error) nothrow {
+        try {
+            this.error = to!wstring(error.toString());
+        } catch(Exception ex) {
+            this.error = "Unhandled Exception while marshalling exception data. You should never see this error.";
+        }
+        pinPointer(cast(void*)this.error.ptr);
+    }
+}
+
+extern(C) export struct datetime {
+    long ticks;
+    long offset;
+
+    public this(Duration value) {
+        this.ticks = value.total!"hnsecs";
+        this.offset = 0;
+    }
+
+    public this(DateTime value) {
+        this.ticks = SysTime(value).stdTime;
+        this.offset = 0;
+    }
+
+    public this(Date value) {
+        this.ticks = SysTime(value).stdTime;
+        this.offset = 0;
+    }
+
+    public this(TimeOfDay value) {
+        import core.time : Duration, hours, minutes, seconds;
+        Duration t = hours(value.hour) + minutes(value.minute) + seconds(value.second);
+        this.ticks = t.total!"hnsecs";
+        this.offset = 0;
+    }
+
+    public this(SysTime value) {
+        this.ticks = value.stdTime;
+        this.offset = value.utcOffset.total!"hnsecs";
+    }
+}
+
+public void pinPointer(void* ptr) nothrow {
+    GC.setAttr(ptr, GC.BlkAttr.NO_MOVE);
+    GC.addRoot(ptr);
+}
+
+public datetime toDatetime(T)(T value)
+if (isDateTimeType!T) {
+    return datetime(value);
+}
+
+public datetime[] toDatetime1DArray(T)(T[] value)
+if (isDateTimeType!T) {
+    import std.algorithm : map;
+    import std.array : array;
+    return value.map!datetime.array;
+}
+
+public T fromDatetime(T)(datetime value)
+if (isDateTimeType!T) {
+    static if (is(T == SysTime)) {
+        return SysTime(value.ticks, cast(immutable)new SimpleTimeZone(hnsecs(value.offset)));
+    } else static if (is(T == DateTime)) {
+        return cast(T)SysTime(value.ticks, LocalTime());
+    } else static if (is(T == Date) || is(T == TimeOfDay)) {
+        return cast(T)SysTime(value.ticks, cast(immutable)new SimpleTimeZone(hnsecs(0)));
+    } else static if (is(T == Duration)) {
+        return hnsecs(value.ticks);
+    }
+}
+
+public T[] fromDatetime1DArray(T)(datetime[] value)
+if (isDateTimeType!T) {
+    import std.algorithm : map;
+    import std.array : array;
+    return value.map!(fromDatetime!T).array;
 }
 
 public string wrapCSharp(in Modules modules, OutputFileName outputFile, LibraryName libraryName, RootNamespace rootNamespace) @safe pure {
     import std.format : format;
     import std.algorithm: map;
     import std.array: join;
+    import autowrap.common;
+    import autowrap.csharp.boilerplate;
 
     if(!__ctfe) return null;
 
     const modulesList = modules.value.map!(a => a.toString).join(", ");
 
     return q{
-        //Insert shared boilerplate code
-        %1$s
-
+        import core.memory : GC;
+        import std.conv : to;
+        import std.utf : toUTF8, toUTF16, toUTF32;
         import std.typecons;
+        import std.string : fromStringz;
         import autowrap.csharp.boilerplate;
         import autowrap.csharp.dlang : wrapDLang;
-
-        immutable string t = wrapDLang!(%2$s);
-        mixin(t);
-        //pragma(msg, t); //Uncomment to see generated D interface code, useful for debugging.
-
-        //Insert DllMain for Windows only.
-        version(Windows) {
-            %3$s
-        }
-
-        void main() {
-            import std.stdio;
-            string generated = generateCSharp!(%2$s)(LibraryName("%4$s"), RootNamespace("%5$s"));
-            auto f = File("%6$s", "w");
-            f.writeln(generated);
-        }
-    }.format(commonBoilerplate(), modulesList, dllMainMixinStr(), libraryName.value, rootNamespace.value, outputFile.value);
-}
-
-/**
-   Returns a string to be mixed in that defines the boilerplate code needed by all C# interfaces.
- */
-private string commonBoilerplate() @safe pure {
-    return q{
-        import std.datetime : DateTime, SysTime, Date, TimeOfDay, SimpleTimeZone, LocalTime;
-        import core.time;
-        import core.memory;
-        import std.conv;
-        import std.string;
-        import std.traits;
-        import std.utf;
-
-        extern(C) export struct returnValue(T) {
-            T value;
-            wstring error;
-
-            this(T value) nothrow {
-                this.value = value;
-                static if (isArray!(T) || is(T == class) || is(T == interface)) {
-                    if (this.value !is null) {
-                        pinPointer(cast(void*)this.error.ptr);
-                    }
-                }
-                this.error = null;
-            }
-
-            this(Exception error) nothrow {
-                this.value = T.init;
-                try {
-                    this.error = to!wstring(error.toString());
-                } catch(Exception ex) {
-                    this.error = "Unhandled Exception while marshalling exception data. You should never see this error.";
-                }
-                pinPointer(cast(void*)this.error.ptr);
-            }
-        }
-
-        extern(C) export struct returnVoid {
-            wstring error = null;
-
-            this(Exception error) nothrow {
-                try {
-                    this.error = to!wstring(error.toString());
-                } catch(Exception ex) {
-                    this.error = "Unhandled Exception while marshalling exception data. You should never see this error.";
-                }
-                pinPointer(cast(void*)this.error.ptr);
-            }
-        }
-
-        mixin(generateSharedTypes());
-
-        public void pinPointer(void* ptr) nothrow {
-            GC.setAttr(ptr, GC.BlkAttr.NO_MOVE);
-            GC.addRoot(ptr);
-        }
-
-        public datetime toDatetime(T)(T value)
-        if (isDateTimeType!T) {
-            return datetime(value);
-        }
-
-        public datetime[] toDatetime1DArray(T)(T[] value)
-        if (isDateTimeType!T) {
-            import std.algorithm : map;
-            import std.array : array;
-            return value.map!datetime.array;
-        }
-
-        public T fromDatetime(T)(datetime value)
-        if (isDateTimeType!T) {
-            static if (is(T == SysTime)) {
-                return SysTime(value.ticks, cast(immutable)new SimpleTimeZone(hnsecs(value.offset)));
-            } else static if (is(T == DateTime)) {
-                return cast(T)SysTime(value.ticks, LocalTime());
-            } else static if (is(T == Date) || is(T == TimeOfDay)) {
-                return cast(T)SysTime(value.ticks, cast(immutable)new SimpleTimeZone(hnsecs(0)));
-            } else static if (is(T == Duration)) {
-                return hnsecs(value.ticks);
-            }
-        }
-
-        public T[] fromDatetime1DArray(T)(datetime[] value)
-        if (isDateTimeType!T) {
-            import std.algorithm : map;
-            import std.array : array;
-            return value.map!(fromDatetime!T).array;
-        }
 
         extern(C) export void autowrap_csharp_release(void* ptr) nothrow {
             GC.clrAttr(ptr, GC.BlkAttr.NO_MOVE);
@@ -165,5 +171,19 @@ private string commonBoilerplate() @safe pure {
             pinPointer(cast(void*)temp.ptr);
             return temp;
         }
-    };
+
+        mixin(wrapDLang!(%1$s));
+
+        //Insert DllMain for Windows only.
+        version(Windows) {
+            %2$s
+        }
+
+        void main() {
+            import std.stdio;
+            string generated = generateCSharp!(%1$s)(LibraryName("%3$s"), RootNamespace("%4$s"));
+            auto f = File("%5$s", "w");
+            f.writeln(generated);
+        }
+    }.format(modulesList, dllMainMixinStr(), libraryName.value, rootNamespace.value, outputFile.value);
 }

--- a/csharp/source/autowrap/csharp/boilerplate.d
+++ b/csharp/source/autowrap/csharp/boilerplate.d
@@ -112,53 +112,35 @@ private string commonBoilerplate() @safe pure {
         }
 
         public datetime toDatetime(T)(T value)
-        if (is(T == SysTime) || is(T == DateTime) || is(T == Date) || is(T == TimeOfDay) || is(T == Duration)) {
+        if (isDateTimeType!T) {
             return datetime(value);
         }
 
-        public datetime[] toDatetimeArray(T)(T value)
-        if (is(T == SysTime[]) || is(T == DateTime[]) || is(T == Date[]) || is(T == TimeOfDay[]) || is(T == Duration[])) {
-            datetime[] array = datetime[].init;
-            array.reserve(value.length);
-            foreach(t; value) {
-                array ~= datetime(t);
-            }
-            return array;
+        public datetime[] toDatetime1DArray(T)(T[] value)
+        if (isDateTimeType!T) {
+            import std.algorithm : map;
+            import std.array : array;
+            return value.map!datetime.array;
         }
 
         public T fromDatetime(T)(datetime value)
-        if (is(T == SysTime) || is(T == DateTime) || is(T == Date) || is(T == TimeOfDay) || is(T == Duration)) {
+        if (isDateTimeType!T) {
             static if (is(T == SysTime)) {
                 return SysTime(value.ticks, cast(immutable)new SimpleTimeZone(hnsecs(value.offset)));
             } else static if (is(T == DateTime)) {
-                return cast(DateTime)SysTime(value.ticks, LocalTime());
-            } else static if (is(T == Date)) {
-                return cast(Date)SysTime(value.ticks, cast(immutable)new SimpleTimeZone(hnsecs(0)));
-            } else static if (is(T == TimeOfDay)) {
-                return cast(TimeOfDay)SysTime(value.ticks, cast(immutable)new SimpleTimeZone(hnsecs(0)));
+                return cast(T)SysTime(value.ticks, LocalTime());
+            } else static if (is(T == Date) || is(T == TimeOfDay)) {
+                return cast(T)SysTime(value.ticks, cast(immutable)new SimpleTimeZone(hnsecs(0)));
             } else static if (is(T == Duration)) {
                 return hnsecs(value.ticks);
             }
         }
 
-        public T fromDatetimeArray(T)(datetime[] value)
-        if (is(T == SysTime[]) || is(T == DateTime[]) || is(T == Date[]) || is(T == TimeOfDay[]) || is(T == Duration[])) {
-            T array = T.init;
-            array.reserve(value.length);
-            foreach(t; value) {
-                static if (is(T == SysTime[])) {
-                    array ~= SysTime(t.ticks, cast(immutable)new SimpleTimeZone(hnsecs(t.offset)));
-                } else static if (is(T == DateTime[])) {
-                    array ~= cast(DateTime)SysTime(t.ticks, LocalTime());
-                } else static if (is(T == Date[])) {
-                    array ~= cast(Date)SysTime(t.ticks, cast(immutable)new SimpleTimeZone(hnsecs(0)));
-                } else static if (is(T == TimeOfDay[])) {
-                    array ~= cast(TimeOfDay)SysTime(t.ticks, cast(immutable)new SimpleTimeZone(hnsecs(0)));
-                } else static if (is(T == Duration[])) {
-                    array ~= hnsecs(t.ticks);
-                }
-            }
-            return array;
+        public T[] fromDatetime1DArray(T)(datetime[] value)
+        if (isDateTimeType!T) {
+            import std.algorithm : map;
+            import std.array : array;
+            return value.map!(fromDatetime!T).array;
         }
 
         extern(C) export void autowrap_csharp_release(void* ptr) nothrow {

--- a/csharp/source/autowrap/csharp/boilerplate.d
+++ b/csharp/source/autowrap/csharp/boilerplate.d
@@ -58,6 +58,7 @@ public string wrapCSharp(in Modules modules, OutputFileName outputFile, LibraryN
  */
 private string commonBoilerplate() @safe pure {
     return q{
+        import std.datetime : DateTime, SysTime, Date, TimeOfDay, Duration;
         import core.memory;
         import std.conv;
         import std.string;
@@ -102,9 +103,61 @@ private string commonBoilerplate() @safe pure {
             }
         }
 
+        mixin(generateSharedTypes());
+
         public void pinPointer(void* ptr) nothrow {
             GC.setAttr(ptr, GC.BlkAttr.NO_MOVE);
             GC.addRoot(ptr);
+        }
+
+        public T datetimeToType(T)(datetime value)
+        if (is(T == SysTime) || is(T == DateTime) || is(T == Date) || is(T == TimeOfDay) || is(T == Duration)) {
+            static if (is(T == SysTime)) {
+                return SysTime(value.ticks, new SimpleTimeZone(hnsecs(value.offset)));
+            } else static if (is(T == DateTime)) {
+                return cast(DateTime)SysTime(value.ticks, new SimpleTimeZone(hnsecs(value.offset)));
+            } else static if (is(T == Date)) {
+                return cast(Date)SysTime(value.ticks, new SimpleTimeZone(hnsecs(value.offset)));
+            } else static if (is(T == TimeOfDay)) {
+                return cast(TimeOfDay)SysTime(value.ticks, new SimpleTimeZone(hnsecs(value.offset)));
+            } else static if (is(T == Duration)) {
+                return Duration(value.ticks);
+            }
+        }
+
+        public T[] datetimeArrayToTypeArray(T)(datetime[] value)
+        if (is(T == SysTime) || is(T == DateTime) || is(T == Date) || is(T == TimeOfDay) || is(T == Duration)) {
+            static if (is(T == SysTime)) {
+                SysTime[] array = SysTime[].init;
+                foreach(t; value) {
+                    array ~= SysTime(value.ticks, new SimpleTimeZone(hnsecs(value.offset)));
+                }
+                return array;
+            } else static if (is(T == DateTime)) {
+                DateTime[] array = DateTime[].init;
+                foreach(t; value) {
+                    array ~= cast(DateTime)SysTime(value.ticks, new SimpleTimeZone(hnsecs(value.offset)));
+                }
+                return array;
+            } else static if (is(T == Date)) {
+                Date[] array = Date[].init;
+                foreach(t; value) {
+                    array ~= cast(Date)SysTime(value.ticks, new SimpleTimeZone(hnsecs(value.offset)));
+                }
+                return array;
+            } else static if (is(T == TimeOfDay)) {
+                TimeOfDay[] array = TimeOfDay[].init;
+                foreach(t; value) {
+                    array ~= cast(TimeOfDay)SysTime(value.ticks, new SimpleTimeZone(hnsecs(value.offset)));
+                }
+                return array;
+            } else static if (is(T == Duration)) {
+                Duration[] array = Duration[].init;
+                foreach(t; value) {
+                    array ~= Duration(value.ticks);
+                }
+                return array;
+            }
         }
 
         extern(C) export void autowrap_csharp_release(void* ptr) nothrow {

--- a/csharp/source/autowrap/csharp/boilerplate.d
+++ b/csharp/source/autowrap/csharp/boilerplate.d
@@ -58,7 +58,8 @@ public string wrapCSharp(in Modules modules, OutputFileName outputFile, LibraryN
  */
 private string commonBoilerplate() @safe pure {
     return q{
-        import std.datetime : DateTime, SysTime, Date, TimeOfDay, Duration;
+        import std.datetime : DateTime, SysTime, Date, TimeOfDay;
+        import core.time : Duration;
         import core.memory;
         import std.conv;
         import std.string;
@@ -110,7 +111,22 @@ private string commonBoilerplate() @safe pure {
             GC.addRoot(ptr);
         }
 
-        public T datetimeToType(T)(datetime value)
+        public datetime toDatetime(T)(T value)
+        if (is(T == SysTime) || is(T == DateTime) || is(T == Date) || is(T == TimeOfDay) || is(T == Duration)) {
+            return datetime(value);
+        }
+
+        public datetime[] toDatetimeArray(T)(T[] value)
+        if (is(T == SysTime) || is(T == DateTime) || is(T == Date) || is(T == TimeOfDay) || is(T == Duration)) {
+            datetime[] array = datetime[].init;
+            array.reserve(value.length);
+            foreach(t; value) {
+                array ~= datetime(value));
+            }
+            return array;
+        }
+
+        public T fromDatetime(T)(datetime value)
         if (is(T == SysTime) || is(T == DateTime) || is(T == Date) || is(T == TimeOfDay) || is(T == Duration)) {
             static if (is(T == SysTime)) {
                 return SysTime(value.ticks, new SimpleTimeZone(hnsecs(value.offset)));
@@ -125,34 +141,39 @@ private string commonBoilerplate() @safe pure {
             }
         }
 
-        public T[] datetimeArrayToTypeArray(T)(datetime[] value)
+        public T[] fromDatetimeArray(T)(datetime[] value)
         if (is(T == SysTime) || is(T == DateTime) || is(T == Date) || is(T == TimeOfDay) || is(T == Duration)) {
             static if (is(T == SysTime)) {
                 SysTime[] array = SysTime[].init;
+                array.reserve(value.length);
                 foreach(t; value) {
                     array ~= SysTime(value.ticks, new SimpleTimeZone(hnsecs(value.offset)));
                 }
                 return array;
             } else static if (is(T == DateTime)) {
                 DateTime[] array = DateTime[].init;
+                array.reserve(value.length);
                 foreach(t; value) {
                     array ~= cast(DateTime)SysTime(value.ticks, new SimpleTimeZone(hnsecs(value.offset)));
                 }
                 return array;
             } else static if (is(T == Date)) {
                 Date[] array = Date[].init;
+                array.reserve(value.length);
                 foreach(t; value) {
                     array ~= cast(Date)SysTime(value.ticks, new SimpleTimeZone(hnsecs(value.offset)));
                 }
                 return array;
             } else static if (is(T == TimeOfDay)) {
                 TimeOfDay[] array = TimeOfDay[].init;
+                array.reserve(value.length);
                 foreach(t; value) {
                     array ~= cast(TimeOfDay)SysTime(value.ticks, new SimpleTimeZone(hnsecs(value.offset)));
                 }
                 return array;
             } else static if (is(T == Duration)) {
                 Duration[] array = Duration[].init;
+                array.reserve(value.length);
                 foreach(t; value) {
                     array ~= Duration(value.ticks);
                 }

--- a/csharp/source/autowrap/csharp/common.d
+++ b/csharp/source/autowrap/csharp/common.d
@@ -16,48 +16,16 @@ public struct RootNamespace {
     string value;
 }
 
-public string generateSharedTypes() {
-    return q{
-        extern(C) export struct datetime {
-            long ticks;
-            long offset;
-
-            public this(Duration value) {
-                this.ticks = value.total!"hnsecs";
-                this.offset = 0;
-            }
-
-            public this(DateTime value) {
-                this.ticks = SysTime(value).stdTime;
-                this.offset = 0;
-            }
-
-            public this(Date value) {
-                this.ticks = SysTime(value).stdTime;
-                this.offset = 0;
-            }
-
-            public this(TimeOfDay value) {
-                import core.time : Duration, hours, minutes, seconds;
-                Duration t = hours(value.hour) + minutes(value.minute) + seconds(value.second);
-                this.ticks = t.total!"hnsecs";
-                this.offset = 0;
-            }
-
-            public this(SysTime value) {
-                this.ticks = value.stdTime;
-                this.offset = value.utcOffset.total!"hnsecs";
-            }
-        }
-    };
+public struct OutputFileName {
+    string value;
 }
 
 package string getDLangInterfaceType(T)() {
     import std.traits : fullyQualifiedName;
     import std.datetime : DateTime, SysTime, Date, TimeOfDay, Duration;
-    if (is(T == Date) || is(T == DateTime) || is(T == SysTime) || is(T == TimeOfDay) || is(T == Duration)) {
+    if (isDateTimeType!T) {
         return "datetime";
-    } else if (is(T == Date[]) || is(T == DateTime[]) || is(T == SysTime[]) || is(T == TimeOfDay[]) || is(T == Duration[])) {
+    } else if (isDateTimeArrayType!T) {
         return "datetime[]";
     } else {
         return fullyQualifiedName!T;

--- a/csharp/source/autowrap/csharp/common.d
+++ b/csharp/source/autowrap/csharp/common.d
@@ -66,7 +66,7 @@ package string getDLangSliceInterfaceName(string fqn, string funcName) {
     string name = "autowrap_csharp_slice_";
 
     if (fqn.among("core.time.Duration", "std.datetime.systime.SysTime", "std.datetime.date.DateTime", "autowrap.csharp.dlang.datetime")) {
-        fqn = "datetime";
+        fqn = "Autowrap_Csharp_Boilerplate_Datetime";
     }
 
     name ~= fqn.split(".").map!camelToPascalCase.join("_");

--- a/csharp/source/autowrap/csharp/common.d
+++ b/csharp/source/autowrap/csharp/common.d
@@ -8,12 +8,23 @@ public struct RootNamespace {
     string value;
 }
 
+public string generateSharedTypes() {
+    return q{
+        extern(C) export struct datetime {
+            long ticks;
+            long offset;
+        }
+    };
+}
+
 package string getInterfaceTypeString(T)() {
-    import std.datetime : DateTime, SysTime;
+    import std.datetime : DateTime, SysTime, Date, TimeOfDay, Duration;
     import std.traits : fullyQualifiedName;
 
-    if (is(T == DateTime) || is(T == SysTime)) {
-        return "wstring";
+    if (is(T == DateTime) || is(T == SysTime) || is(T == Date) || is(T == TimeOfDay)) {
+        return "datetime";
+    } else if (is(T == Duration)) {
+        return "long";
     }
 
     return fullyQualifiedName!T;

--- a/csharp/source/autowrap/csharp/common.d
+++ b/csharp/source/autowrap/csharp/common.d
@@ -30,8 +30,9 @@ public string generateSharedTypes() {
             }
 
             public this(TimeOfDay value) {
-                Duration t = dur!"hours"(value.hour) + dur!"minutes"(value.minute) + dur!"seconds"(value.second);
-                this.ticks = value.total!"hnsecs";
+                import core.time : Duration, hours, minutes, seconds;
+                Duration t = hours(value.hour) + minutes(value.minute) + seconds(value.second);
+                this.ticks = t.total!"hnsecs";
                 this.offset = 0;
             }
 
@@ -41,6 +42,18 @@ public string generateSharedTypes() {
             }
         }
     };
+}
+
+package string getDLangInterfaceType(T)() {
+    import std.traits : fullyQualifiedName;
+    import std.datetime : DateTime, SysTime, Date, TimeOfDay, Duration;
+    if (is(T == Date) || is(T == DateTime) || is(T == SysTime) || is(T == TimeOfDay) || is(T == Duration)) {
+        return "datetime";
+    } else if (is(T == Date[]) || is(T == DateTime[]) || is(T == SysTime[]) || is(T == TimeOfDay[]) || is(T == Duration[])) {
+        return "datetime[]";
+    } else {
+        return fullyQualifiedName!T;
+    }
 }
 
 package string getInterfaceTypeString(T)() {
@@ -83,7 +96,12 @@ package string getDLangSliceInterfaceName(string fqn, string funcName) {
     import std.algorithm : map;
     import std.string : split;
     import std.array : join;
+
     string name = "autowrap_csharp_slice_";
+
+    if (fqn == "core.time.Duration" || fqn == "std.datetime.systime.SysTime" || fqn == "std.datetime.date.DateTime" || fqn == "autowrap.csharp.dlang.datetime") {
+        fqn = "datetime";
+    }
 
     name ~= fqn.split(".").map!camelToPascalCase.join("_");
     name ~= camelToPascalCase(funcName);

--- a/csharp/source/autowrap/csharp/common.d
+++ b/csharp/source/autowrap/csharp/common.d
@@ -13,6 +13,32 @@ public string generateSharedTypes() {
         extern(C) export struct datetime {
             long ticks;
             long offset;
+
+            public this(Duration value) {
+                this.ticks = value.total!"hnsecs";
+                this.offset = 0;
+            }
+
+            public this(DateTime value) {
+                this.ticks = SysTime(value).stdTime;
+                this.offset = 0;
+            }
+
+            public this(Date value) {
+                this.ticks = SysTime(value).stdTime;
+                this.offset = 0;
+            }
+
+            public this(TimeOfDay value) {
+                Duration t = dur!"hours"(value.hour) + dur!"minutes"(value.minute) + dur!"seconds"(value.second);
+                this.ticks = value.total!"hnsecs";
+                this.offset = 0;
+            }
+
+            public this(SysTime value) {
+                this.ticks = value.stdTime;
+                this.offset = value.utcOffset.total!"hnsecs";
+            }
         }
     };
 }
@@ -21,10 +47,8 @@ package string getInterfaceTypeString(T)() {
     import std.datetime : DateTime, SysTime, Date, TimeOfDay, Duration;
     import std.traits : fullyQualifiedName;
 
-    if (is(T == DateTime) || is(T == SysTime) || is(T == Date) || is(T == TimeOfDay)) {
+    if (is(T == DateTime) || is(T == SysTime) || is(T == Date) || is(T == TimeOfDay) || is(T == Duration)) {
         return "datetime";
-    } else if (is(T == Duration)) {
-        return "long";
     }
 
     return fullyQualifiedName!T;

--- a/csharp/source/autowrap/csharp/common.d
+++ b/csharp/source/autowrap/csharp/common.d
@@ -13,7 +13,7 @@ package string getInterfaceTypeString(T)() {
     import std.traits : fullyQualifiedName;
 
     if (is(T == DateTime) || is(T == SysTime)) {
-        return fullyQualifiedName!T;
+        return "wstring";
     }
 
     return fullyQualifiedName!T;

--- a/csharp/source/autowrap/csharp/common.d
+++ b/csharp/source/autowrap/csharp/common.d
@@ -2,6 +2,11 @@ module autowrap.csharp.common;
 
 import std.datetime : DateTime, SysTime, Date, TimeOfDay, Duration;
 
+public enum isDateTimeType(T) = is(T == Date) || is(T == DateTime) || is(T == SysTime) || is(T == TimeOfDay) || is(T == Duration);
+public enum isDateTimeArrayType(T) = is(T == Date[]) || is(T == DateTime[]) || is(T == SysTime[]) || is(T == TimeOfDay[]) || is(T == Duration[]);
+
+enum string[] excludedMethods = ["toHash", "opEquals", "opCmp", "factory", "__ctor"];
+
 public struct LibraryName {
     string value;
 }
@@ -12,9 +17,6 @@ public struct RootNamespace {
 
 public string generateSharedTypes() {
     return q{
-        enum isDateTimeType(T) = is(T == Date) || is(T == DateTime) || is(T == SysTime) || is(T == TimeOfDay) || is(T == Duration);
-        enum isDateTimeArrayType(T) = is(T == Date[]) || is(T == DateTime[]) || is(T == SysTime[]) || is(T == TimeOfDay[]) || is(T == Duration[]);
-
         extern(C) export struct datetime {
             long ticks;
             long offset;
@@ -65,6 +67,7 @@ package string getDLangInterfaceName(string moduleName, string aggName, string f
     import std.algorithm : map;
     import std.string : split;
     import std.array : join;
+
     string name = "autowrap_csharp_";
     name ~= moduleName.split(".").map!camelToPascalCase.join("_");
 
@@ -87,13 +90,13 @@ package string getDLangInterfaceName(string fqn, string funcName) {
 }
 
 package string getDLangSliceInterfaceName(string fqn, string funcName) {
-    import std.algorithm : map;
+    import std.algorithm : map, among;
     import std.string : split;
     import std.array : join;
 
     string name = "autowrap_csharp_slice_";
 
-    if (fqn == "core.time.Duration" || fqn == "std.datetime.systime.SysTime" || fqn == "std.datetime.date.DateTime" || fqn == "autowrap.csharp.dlang.datetime") {
+    if (fqn.among("core.time.Duration", "std.datetime.systime.SysTime", "std.datetime.date.DateTime", "autowrap.csharp.dlang.datetime")) {
         fqn = "datetime";
     }
 

--- a/csharp/source/autowrap/csharp/common.d
+++ b/csharp/source/autowrap/csharp/common.d
@@ -1,9 +1,10 @@
 module autowrap.csharp.common;
 
-import std.datetime : DateTime, SysTime, Date, TimeOfDay, Duration;
+public import std.datetime : DateTime, SysTime, Date, TimeOfDay, Duration, TimeZone;
+public import std.traits : Unqual;
 
-public enum isDateTimeType(T) = is(T == Date) || is(T == DateTime) || is(T == SysTime) || is(T == TimeOfDay) || is(T == Duration);
-public enum isDateTimeArrayType(T) = is(T == Date[]) || is(T == DateTime[]) || is(T == SysTime[]) || is(T == TimeOfDay[]) || is(T == Duration[]);
+public enum isDateTimeType(T) = is(T == Unqual!Date) || is(T == Unqual!DateTime) || is(T == Unqual!SysTime) || is(T == Unqual!TimeOfDay) || is(T == Unqual!Duration) || is(T == Unqual!TimeZone);
+public enum isDateTimeArrayType(T) = is(T == Unqual!(Date[])) || is(T == Unqual!(DateTime[])) || is(T == Unqual!(SysTime[])) || is(T == Unqual!(TimeOfDay[])) || is(T == Unqual!(Duration[])) || is(T == Unqual!(TimeZone[]));
 
 enum string[] excludedMethods = ["toHash", "opEquals", "opCmp", "factory", "__ctor"];
 

--- a/csharp/source/autowrap/csharp/common.d
+++ b/csharp/source/autowrap/csharp/common.d
@@ -1,5 +1,7 @@
 module autowrap.csharp.common;
 
+import std.datetime : DateTime, SysTime, Date, TimeOfDay, Duration;
+
 public struct LibraryName {
     string value;
 }
@@ -10,6 +12,9 @@ public struct RootNamespace {
 
 public string generateSharedTypes() {
     return q{
+        enum isDateTimeType(T) = is(T == Date) || is(T == DateTime) || is(T == SysTime) || is(T == TimeOfDay) || is(T == Duration);
+        enum isDateTimeArrayType(T) = is(T == Date[]) || is(T == DateTime[]) || is(T == SysTime[]) || is(T == TimeOfDay[]) || is(T == Duration[]);
+
         extern(C) export struct datetime {
             long ticks;
             long offset;
@@ -54,17 +59,6 @@ package string getDLangInterfaceType(T)() {
     } else {
         return fullyQualifiedName!T;
     }
-}
-
-package string getInterfaceTypeString(T)() {
-    import std.datetime : DateTime, SysTime, Date, TimeOfDay, Duration;
-    import std.traits : fullyQualifiedName;
-
-    if (is(T == DateTime) || is(T == SysTime) || is(T == Date) || is(T == TimeOfDay) || is(T == Duration)) {
-        return "datetime";
-    }
-
-    return fullyQualifiedName!T;
 }
 
 package string getDLangInterfaceName(string moduleName, string aggName, string funcName) {

--- a/csharp/source/autowrap/csharp/csharp.d
+++ b/csharp/source/autowrap/csharp/csharp.d
@@ -662,12 +662,12 @@ private string getCSharpInterfaceType(string type) {
 }
 
 private string getDLangReturnType(string type, bool isClass) {
-    import std.stdio;
+    import std.algorithm : among;
 
     string rtname = getReturnErrorTypeName(getDLangInterfaceType(type));
     //These types have predefined C# types.
-    if (type == dateTypeString || type == dateTimeTypeString || type == sysTimeTypeString || type == timeOfDayTypeString || type == durationTypeString ||
-        type == voidTypeString || type == boolTypeString || type == stringTypeString || type == wstringTypeString || type == dstringTypeString || rtname == "return_slice_error") {
+    if (type.among(dateTypeString, dateTimeTypeString, sysTimeTypeString, timeOfDayTypeString, durationTypeString,
+        voidTypeString, boolTypeString, stringTypeString, wstringTypeString, dstringTypeString) || rtname == "return_slice_error") {
         return rtname;
     }
 

--- a/csharp/source/autowrap/csharp/csharp.d
+++ b/csharp/source/autowrap/csharp/csharp.d
@@ -18,8 +18,11 @@ enum string stringTypeString = "string";
 enum string wstringTypeString = "wstring";
 enum string dstringTypeString = "dstring";
 enum string boolTypeString = "bool";
-enum string dateTimeTypeString = "DateTime";
-enum string sysTimeTypeString = "SysTime";
+enum string dateTimeTypeString = "std.datetime.date.DateTime";
+enum string sysTimeTypeString = "std.datetime.systime.SysTime";
+enum string dateTypeString = "std.datetime.date.Date";
+enum string timeOfDayTypeString = "std.datetime.date.TimeOfDay";
+enum string durationTypeString = "core.time.Duration";
 enum string uuidTypeString = "UUID";
 enum string charTypeString = "char";
 enum string wcharTypeString = "wchar";
@@ -383,11 +386,11 @@ private void generateProperties(T)(string libraryName, CSharpAggregate csagg) if
                         } else if (is(propertyType == dstring)) {
                             prop ~= mixin(interp!"get => SharedFunctions.SliceToString(dlang_${methodInterfaceName}(${is(T == class) ? string.init : \"ref \"}this), DStringType._dstring);");
                         } else if (is(propertyType == string[])) {
-                            prop ~= mixin(interp!"get => new Range<${getCSharpInterfaceType(fullyQualifiedName!propertyType)}>(dlang_${methodInterfaceName}(${is(T == class) ? string.init : \"ref \"}this), DStringType._string); ");
+                            prop ~= mixin(interp!"get => new Range<string>(dlang_${methodInterfaceName}(${is(T == class) ? string.init : \"ref \"}this), DStringType._string); ");
                         } else if (is(propertyType == wstring[])) {
-                            prop ~= mixin(interp!"get => new Range<${getCSharpInterfaceType(fullyQualifiedName!propertyType)}>(dlang_${methodInterfaceName}(${is(T == class) ? string.init : \"ref \"}this), DStringType._wstring); ");
+                            prop ~= mixin(interp!"get => new Range<string>(dlang_${methodInterfaceName}(${is(T == class) ? string.init : \"ref \"}this), DStringType._wstring); ");
                         } else if (is(propertyType == dstring[])) {
-                            prop ~= mixin(interp!"get => new Range<${getCSharpInterfaceType(fullyQualifiedName!propertyType)}>(dlang_${methodInterfaceName}(${is(T == class) ? string.init : \"ref \"}this), DStringType._dstring); ");
+                            prop ~= mixin(interp!"get => new Range<string>(dlang_${methodInterfaceName}(${is(T == class) ? string.init : \"ref \"}this), DStringType._dstring); ");
                         } else if (isArray!(propertyType)) {
                             prop ~= mixin(interp!"get => new Range<${getCSharpInterfaceType(fullyQualifiedName!propertyType)}>(dlang_${methodInterfaceName}(${is(T == class) ? string.init : \"ref \"}this), DStringType.None); ");
                         } else if (is(propertyType == class)) {
@@ -448,17 +451,17 @@ private void generateFields(T)(string libraryName, CSharpAggregate csagg) if (is
                 }
 
                 if (is(fieldTypes[fc] == string)) {
-                    csagg.properties ~= mixin(interp!"        public ${getCSharpInterfaceType(fullyQualifiedName!(fieldTypes[fc]))} ${getCSharpName(fieldNames[fc])} { get => SharedFunctions.SliceToString(dlang_${fieldNames[fc]}_get(this), DStringType._string); set => dlang_${fieldNames[fc]}_set(this, SharedFunctions.CreateString(value)); }${newline}");
+                    csagg.properties ~= mixin(interp!"        public string ${getCSharpName(fieldNames[fc])} { get => SharedFunctions.SliceToString(dlang_${fieldNames[fc]}_get(this), DStringType._string); set => dlang_${fieldNames[fc]}_set(this, SharedFunctions.CreateString(value)); }${newline}");
                 } else if (is(fieldTypes[fc] == wstring)) {
-                    csagg.properties ~= mixin(interp!"        public ${getCSharpInterfaceType(fullyQualifiedName!(fieldTypes[fc]))} ${getCSharpName(fieldNames[fc])} { get => SharedFunctions.SliceToString(dlang_${fieldNames[fc]}_get(this), DStringType._wstring); set => dlang_${fieldNames[fc]}_set(this, SharedFunctions.CreateWstring(value)); }${newline}");
+                    csagg.properties ~= mixin(interp!"        public string ${getCSharpName(fieldNames[fc])} { get => SharedFunctions.SliceToString(dlang_${fieldNames[fc]}_get(this), DStringType._wstring); set => dlang_${fieldNames[fc]}_set(this, SharedFunctions.CreateWstring(value)); }${newline}");
                 } else if (is(fieldTypes[fc] == dstring)) {
-                    csagg.properties ~= mixin(interp!"        public ${getCSharpInterfaceType(fullyQualifiedName!(fieldTypes[fc]))} ${getCSharpName(fieldNames[fc])} { get => SharedFunctions.SliceToString(dlang_${fieldNames[fc]}_get(this), DStringType._dstring); set => dlang_${fieldNames[fc]}_set(this, SharedFunctions.CreateDstring(value)); }${newline}");
+                    csagg.properties ~= mixin(interp!"        public string ${getCSharpName(fieldNames[fc])} { get => SharedFunctions.SliceToString(dlang_${fieldNames[fc]}_get(this), DStringType._dstring); set => dlang_${fieldNames[fc]}_set(this, SharedFunctions.CreateDstring(value)); }${newline}");
                 } else if (is(fieldTypes[fc] == string[])) {
-                    csagg.properties ~= mixin(interp!"        public Range<${getCSharpInterfaceType(fullyQualifiedName!(fieldTypes[fc]))}> ${getCSharpName(fieldNames[fc])} { get => new Range<${getCSharpInterfaceType(fullyQualifiedName!(fieldTypes[fc]))}>(dlang_${fieldNames[fc]}_get(this), DStringType._string); set => dlang_${fieldNames[fc]}_set(this, value.ToSlice(DStringType._string)); }${newline}");
+                    csagg.properties ~= mixin(interp!"        public Range<string> ${getCSharpName(fieldNames[fc])} { get => new Range<string>(dlang_${fieldNames[fc]}_get(this), DStringType._string); set => dlang_${fieldNames[fc]}_set(this, value.ToSlice(DStringType._string)); }${newline}");
                 } else if (is(fieldTypes[fc] == wstring[])) {
-                    csagg.properties ~= mixin(interp!"        public Range<${getCSharpInterfaceType(fullyQualifiedName!(fieldTypes[fc]))}> ${getCSharpName(fieldNames[fc])} { get => new Range<${getCSharpInterfaceType(fullyQualifiedName!(fieldTypes[fc]))}>(dlang_${fieldNames[fc]}_get(this), DStringType._wstring); set => dlang_${fieldNames[fc]}_set(this, value.ToSlice(DStringType._wstring)); }${newline}");
+                    csagg.properties ~= mixin(interp!"        public Range<string> ${getCSharpName(fieldNames[fc])} { get => new Range<string>(dlang_${fieldNames[fc]}_get(this), DStringType._wstring); set => dlang_${fieldNames[fc]}_set(this, value.ToSlice(DStringType._wstring)); }${newline}");
                 } else if (is(fieldTypes[fc] == dstring[])) {
-                    csagg.properties ~= mixin(interp!"        public Range<${getCSharpInterfaceType(fullyQualifiedName!(fieldTypes[fc]))}> ${getCSharpName(fieldNames[fc])} { get => new Range<${getCSharpInterfaceType(fullyQualifiedName!(fieldTypes[fc]))}>(dlang_${fieldNames[fc]}_get(this), DStringType._dstring); set => dlang_${fieldNames[fc]}_set(this, value.ToSlice(DStringType._dstring)); }${newline}");
+                    csagg.properties ~= mixin(interp!"        public Range<string> ${getCSharpName(fieldNames[fc])} { get => new Range<string>(dlang_${fieldNames[fc]}_get(this), DStringType._dstring); set => dlang_${fieldNames[fc]}_set(this, value.ToSlice(DStringType._dstring)); }${newline}");
                 } else if (isArray!(fieldTypes[fc])) {
                     csagg.properties ~= mixin(interp!"        public Range<${getCSharpInterfaceType(fullyQualifiedName!(fieldTypes[fc]))}> ${getCSharpName(fieldNames[fc])} { get => new Range<${getCSharpInterfaceType(fullyQualifiedName!(fieldTypes[fc]))}>(dlang_${fieldNames[fc]}_get(this), DStringType.None); set => dlang_${fieldNames[fc]}_set(this, value.ToSlice()); }${newline}");
                 } else if (is(fieldTypes[fc] == class)) {
@@ -471,14 +474,22 @@ private void generateFields(T)(string libraryName, CSharpAggregate csagg) if (is
     } else if(is(T == struct)) {
         static foreach(fc; 0..fieldTypes.length) {
             static if (is(typeof(__traits(getMember, T, fieldNames[fc])))) {
-                if (is(fieldTypes[fc] == string) || is(fieldTypes[fc] == wstring) || is(fieldTypes[fc] == dstring)) {
+                if (isArray!(fieldTypes[fc])) {
                     csagg.properties ~= mixin(interp!"        private slice _${getCSharpName(fieldNames[fc])};${newline}");
                     if (is(fieldTypes[fc] == string)) {
-                        csagg.properties ~= mixin(interp!"        public string ${getCSharpName(fieldNames[fc])} { get => SharedFunctions.SliceToString(_${getCSharpName(fieldNames[fc])}, DStringType._${fullyQualifiedName!(fieldTypes[fc])}); set => _${getCSharpName(fieldNames[fc])} = SharedFunctions.CreateString(value); }${newline}");
+                        csagg.properties ~= mixin(interp!"        public string ${getCSharpName(fieldNames[fc])} { get => SharedFunctions.SliceToString(_${getCSharpName(fieldNames[fc])}, DStringType._string); set => _${getCSharpName(fieldNames[fc])} = SharedFunctions.CreateString(value); }${newline}");
                     } else if (is(fieldTypes[fc] == wstring)) {
-                        csagg.properties ~= mixin(interp!"        public string ${getCSharpName(fieldNames[fc])} { get => SharedFunctions.SliceToString(_${getCSharpName(fieldNames[fc])}, DStringType._${fullyQualifiedName!(fieldTypes[fc])}); set => _${getCSharpName(fieldNames[fc])} = SharedFunctions.CreateWstring(value); }${newline}");
+                        csagg.properties ~= mixin(interp!"        public string ${getCSharpName(fieldNames[fc])} { get => SharedFunctions.SliceToString(_${getCSharpName(fieldNames[fc])}, DStringType._wstring); set => _${getCSharpName(fieldNames[fc])} = SharedFunctions.CreateWstring(value); }${newline}");
                     } else if (is(fieldTypes[fc] == dstring)) {
-                        csagg.properties ~= mixin(interp!"        public string ${getCSharpName(fieldNames[fc])} { get => SharedFunctions.SliceToString(_${getCSharpName(fieldNames[fc])}, DStringType._${fullyQualifiedName!(fieldTypes[fc])}); set => _${getCSharpName(fieldNames[fc])} = SharedFunctions.CreateDstring(value); }${newline}");
+                        csagg.properties ~= mixin(interp!"        public string ${getCSharpName(fieldNames[fc])} { get => SharedFunctions.SliceToString(_${getCSharpName(fieldNames[fc])}, DStringType._dstring); set => _${getCSharpName(fieldNames[fc])} = SharedFunctions.CreateDstring(value); }${newline}");
+                    } else if (is(fieldTypes[fc] == string[])) {
+                        csagg.properties ~= mixin(interp!"        public Range<string> ${getCSharpName(fieldNames[fc])} { get => new Range<string>(_${fieldNames[fc]}, DStringType._string); set => _${fieldNames[fc]} = value.ToSlice(DStringType._string); }${newline}");
+                    } else if (is(fieldTypes[fc] == wstring[])) {
+                        csagg.properties ~= mixin(interp!"        public Range<string> ${getCSharpName(fieldNames[fc])} { get => new Range<string>(_${fieldNames[fc]}, DStringType._wstring); set => _${fieldNames[fc]} = value.ToSlice(DStringType._wstring); }${newline}");
+                    } else if (is(fieldTypes[fc] == dstring[])) {
+                        csagg.properties ~= mixin(interp!"        public Range<string> ${getCSharpName(fieldNames[fc])} { get => new Range<string>(_${fieldNames[fc]}, DStringType._dstring); set => _${fieldNames[fc]} = value.ToSlice(DStringType._dstring); }${newline}");
+                    } else {
+                        csagg.properties ~= mixin(interp!"        public Range<${getCSharpInterfaceType(fullyQualifiedName!(fieldTypes[fc]))}> ${getCSharpName(fieldNames[fc])} { get => new Range<${getCSharpInterfaceType(fullyQualifiedName!(fieldTypes[fc]))}>(_${fieldNames[fc]}, DStringType.None); set => _${fieldNames[fc]} = value.ToSlice(); }${newline}");
                     }
                 } else if (is(fieldTypes[fc] == bool)) {
                     csagg.properties ~= mixin(interp!"        [MarshalAs(UnmanagedType.U1)] public ${getDLangInterfaceType(fullyQualifiedName!(fieldTypes[fc]))} ${getCSharpName(fieldNames[fc])};${newline}");
@@ -567,11 +578,11 @@ private void generateFunctions(Modules...)(string libraryName) if(allSatisfy!(is
             } else if (is(returnType == dstring)) {
                 funcStr ~= "            return SharedFunctions.SliceToString(dlang_ret, DStringType._dstring);" ~ newline;
             } else if (is(returnType == string[])) {
-                funcStr ~= mixin(interp!"            return new Range<${getCSharpInterfaceType(returnTypeStr)}>(dlang_ret, DStringType._string);${newline}");
+                funcStr ~= mixin(interp!"            return new Range<string>(dlang_ret, DStringType._string);${newline}");
             } else if (is(returnType == wstring[])) {
-                funcStr ~= mixin(interp!"            return new Range<${getCSharpInterfaceType(returnTypeStr)}>(dlang_ret, DStringType._wstring);${newline}");
+                funcStr ~= mixin(interp!"            return new Range<string>(dlang_ret, DStringType._wstring);${newline}");
             } else if (is(returnType == dstring[])) {
-                funcStr ~= mixin(interp!"            return new Range<${getCSharpInterfaceType(returnTypeStr)}>(dlang_ret, DStringType._dstring);${newline}");
+                funcStr ~= mixin(interp!"            return new Range<string>(dlang_ret, DStringType._dstring);${newline}");
             } else if (isArray!(returnType)) {
                 funcStr ~= mixin(interp!"            return new Range<${getCSharpInterfaceType(returnTypeStr)}>(dlang_ret, DStringType.None);${newline}");
             } else {
@@ -592,8 +603,11 @@ private string getDLangInterfaceType(string type) {
         case stringTypeString: return "slice";
         case wstringTypeString: return "slice";
         case dstringTypeString: return "slice";
-        case dateTimeTypeString: return "slice";
-        case sysTimeTypeString: return "slice";
+        case sysTimeTypeString: return "datetime";
+        case dateTimeTypeString: return "datetime";
+        case timeOfDayTypeString: return "datetime";
+        case dateTypeString: return "datetime";
+        case durationTypeString: return "datetime";
         case boolTypeString: return "bool";
 
         //Types that can be marshalled by default
@@ -623,8 +637,11 @@ private string getCSharpInterfaceType(string type) {
         case stringTypeString: return "string";
         case wstringTypeString: return "string";
         case dstringTypeString: return "string";
-        case dateTimeTypeString: return "DateTime";
         case sysTimeTypeString: return "DateTimeOffset";
+        case dateTimeTypeString: return "DateTime";
+        case timeOfDayTypeString: return "DateTime";
+        case dateTypeString: return "DateTime";
+        case durationTypeString: return "TimeSpan";
         case boolTypeString: return "bool";
 
         //Types that can be marshalled by default
@@ -650,7 +667,8 @@ private string getDLangReturnType(string type, bool isClass) {
 
     string rtname = getReturnErrorTypeName(getDLangInterfaceType(type));
     //These types have predefined C# types.
-    if(type == voidTypeString || type == boolTypeString || type == stringTypeString || type == wstringTypeString || type == dstringTypeString || rtname == "return_slice_error") {
+    if (type == dateTypeString || type == dateTimeTypeString || type == sysTimeTypeString || type == timeOfDayTypeString || type == durationTypeString ||
+        type == voidTypeString || type == boolTypeString || type == stringTypeString || type == wstringTypeString || type == dstringTypeString || rtname == "return_slice_error") {
         return rtname;
     }
 
@@ -747,15 +765,17 @@ private void generateRangeDef(T)(string libraryName) {
         rangeDef.functions ~= dllImportString.format(libraryName, getDLangSliceInterfaceName(fqn, "Get"));
         rangeDef.functions ~= externFuncString.format(getDLangReturnType(fqn, false), getCSharpMethodInterfaceName(fqn, "Get"), "slice dslice, IntPtr index");
         rangeDef.functions ~= dllImportString.format(libraryName, getDLangSliceInterfaceName(fqn, "Set"));
-        rangeDef.functions ~= externFuncString.format("return_void_error", getCSharpMethodInterfaceName(fqn, "Set"), mixin(interp!"slice dslice, IntPtr index, ${getCSharpInterfaceType(fqn)} value"));
+        rangeDef.functions ~= externFuncString.format("return_void_error", getCSharpMethodInterfaceName(fqn, "Set"), mixin(interp!"slice dslice, IntPtr index, ${getDLangInterfaceType(fqn)} value"));
         rangeDef.functions ~= dllImportString.format(libraryName, getDLangSliceInterfaceName(fqn, "AppendValue"));
-        rangeDef.functions ~= externFuncString.format("return_slice_error", getCSharpMethodInterfaceName(fqn, "AppendValue"), mixin(interp!"slice dslice, ${getCSharpInterfaceType(fqn)} value"));
+        rangeDef.functions ~= externFuncString.format("return_slice_error", getCSharpMethodInterfaceName(fqn, "AppendValue"), mixin(interp!"slice dslice, ${getDLangInterfaceType(fqn)} value"));
         rangeDef.getters ~= mixin(interp!"                else if (typeof(T) == typeof(${getCSharpInterfaceType(fqn)})) return (T)(object)(${getCSharpInterfaceType(fqn)})RangeFunctions.${getCSharpMethodInterfaceName(fqn, \"Get\")}(_slice, new IntPtr(i));${newline}");
         rangeDef.enumerators ~= mixin(interp!"                else if (typeof(T) == typeof(${getCSharpInterfaceType(fqn)})) yield return (T)(object)(${getCSharpInterfaceType(fqn)})RangeFunctions.${getCSharpMethodInterfaceName(fqn, \"Get\")}(_slice, new IntPtr(i));${newline}");
     }
 }
 
 private void generateSliceBoilerplate(string libraryName) {
+    import std.datetime: Date, DateTime, TimeOfDay, SysTime, Duration;
+
     void generateStringBoilerplate(string dlangType, string csharpType) {
         rangeDef.enumerators ~= mixin(interp!"                else if (typeof(T) == typeof(string) && _strings == null && _type == DStringType._${dlangType}) yield return (T)(object)SharedFunctions.SliceToString(RangeFunctions.${csharpType}_Get(_slice, new IntPtr(i)), DStringType._${dlangType});${newline}");
         rangeDef.getters ~= mixin(interp!"                else if (typeof(T) == typeof(string) && _strings == null && _type == DStringType._${dlangType}) return (T)(object)SharedFunctions.SliceToString(RangeFunctions.${csharpType}_Get(_slice, new IntPtr(i)), DStringType._${dlangType});${newline}");
@@ -824,6 +844,10 @@ private void generateSliceBoilerplate(string libraryName) {
     generateRangeDef!ulong(libraryName);
     generateRangeDef!float(libraryName);
     generateRangeDef!double(libraryName);
+
+    generateRangeDef!DateTime(libraryName);
+    generateRangeDef!SysTime(libraryName);
+    generateRangeDef!Duration(libraryName);
 }
 
 private string writeCSharpBoilerplate(string libraryName, string rootNamespace) {

--- a/csharp/source/autowrap/csharp/csharp.d
+++ b/csharp/source/autowrap/csharp/csharp.d
@@ -140,14 +140,14 @@ public struct csharpRange {
 
 public string generateCSharp(Modules...)(LibraryName libraryName, RootNamespace rootNamespace) if(allSatisfy!(isModule, Modules)) {
     import core.time : Duration;
-    import std.datetime : Date, DateTime, SysTime, TimeOfDay, TimeZone;
+    import autowrap.csharp.common : isDateTimeType;
     import autowrap.reflection : AllAggregates;
 
     generateSliceBoilerplate(libraryName.value);
 
     alias aggregates = AllAggregates!Modules;
     static foreach(agg; aggregates) {
-        static if (!(is(agg == Date) || is(agg == DateTime) || is(agg == SysTime) || is(agg == TimeOfDay) || is(agg == Duration) || is(agg == TimeZone))) {
+        static if (!(isDateTimeType!agg)) {
             generateRangeDef!agg(libraryName.value);
             generateConstructors!agg(libraryName.value);
             generateMethods!agg(libraryName.value);
@@ -782,7 +782,7 @@ private void generateRangeDef(T)(string libraryName) {
 }
 
 private void generateSliceBoilerplate(string libraryName) {
-    import std.datetime: Date, DateTime, TimeOfDay, SysTime, Duration;
+    import std.datetime: DateTime, SysTime, Duration;
 
     void generateStringBoilerplate(string dlangType, string csharpType) {
         rangeDef.enumerators ~= mixin(interp!"                else if (typeof(T) == typeof(string) && _strings == null && _type == DStringType._${dlangType}) yield return (T)(object)SharedFunctions.SliceToString(RangeFunctions.${csharpType}_Get(_slice, new IntPtr(i)), DStringType._${dlangType});${newline}");

--- a/csharp/source/autowrap/csharp/csharp.d
+++ b/csharp/source/autowrap/csharp/csharp.d
@@ -174,16 +174,13 @@ private void generateConstructors(T)(string libraryName, CSharpAggregate csagg) 
     import autowrap.csharp.common : getDLangInterfaceName;
     import std.traits : fullyQualifiedName, hasMember, Parameters, ParameterIdentifierTuple;
     import std.meta: AliasSeq;
+    import std.algorithm : among;
 
     const string aggName = __traits(identifier, T);
     alias fqn = fullyQualifiedName!T;
 
-    static if(hasMember!(T, "__ctor")) {
-        static if (__traits(getProtection, __traits(getMember, T, "__ctor")) == "export" || __traits(getProtection, __traits(getMember, T, "__ctor")) == "public") {
-            alias constructors = AliasSeq!(__traits(getOverloads, T, "__ctor"));
-        } else {
-            alias constructors = AliasSeq!();
-        }
+    static if(hasMember!(T, "__ctor") && __traits(getProtection, __traits(getMember, T, "__ctor")).among("export", "public")) {
+        alias constructors = AliasSeq!(__traits(getOverloads, T, "__ctor"));
     } else {
         alias constructors = AliasSeq!();
     }

--- a/csharp/source/autowrap/csharp/csharp.d
+++ b/csharp/source/autowrap/csharp/csharp.d
@@ -604,6 +604,8 @@ private string getDLangInterfaceType(string type) {
         case stringTypeString: return "slice";
         case wstringTypeString: return "slice";
         case dstringTypeString: return "slice";
+        case dateTimeTypeString: return "slice";
+        case sysTimeTypeString: return "slice";
         case boolTypeString: return "bool";
 
         //Types that can be marshalled by default
@@ -633,6 +635,8 @@ private string getCSharpInterfaceType(string type) {
         case stringTypeString: return "string";
         case wstringTypeString: return "string";
         case dstringTypeString: return "string";
+        case dateTimeTypeString: return "DateTime";
+        case sysTimeTypeString: return "DateTimeOffset";
         case boolTypeString: return "bool";
 
         //Types that can be marshalled by default

--- a/csharp/source/autowrap/csharp/csharp.d
+++ b/csharp/source/autowrap/csharp/csharp.d
@@ -2,8 +2,8 @@ module autowrap.csharp.csharp;
 
 import scriptlike : interp, _interp_text;
 
-import autowrap.csharp.common : LibraryName, RootNamespace, getDLangInterfaceType;
-import autowrap.reflection : isModule;
+import autowrap.csharp.common : LibraryName, RootNamespace, getDLangInterfaceType, OutputFileName;
+import autowrap.reflection : isModule, Modules;
 
 import std.ascii : newline;
 import std.meta: allSatisfy;

--- a/csharp/source/autowrap/csharp/dlang.d
+++ b/csharp/source/autowrap/csharp/dlang.d
@@ -4,17 +4,18 @@ import scriptlike : interp, _interp_text;
 
 import core.time : Duration;
 import std.datetime : Date, DateTime, SysTime, TimeOfDay, TimeZone;
-import autowrap.csharp.common : generateSharedTypes, getDLangInterfaceType;
-import autowrap.reflection : isModule, PrimordialType;
 import std.ascii : newline;
 import std.meta : allSatisfy;
+
+import autowrap.csharp.boilerplate;
+import autowrap.csharp.common : getDLangInterfaceType;
+import autowrap.reflection : isModule, PrimordialType;
 
 enum string methodSetup = "        thread_attachThis();
         rt_moduleTlsCtor();
         scope(exit) rt_moduleTlsDtor();
         scope(exit) thread_detachThis();";
 
-mixin(generateSharedTypes());
 
 // Wrap global functions from multiple modules
 public string wrapDLang(Modules...)() if(allSatisfy!(isModule, Modules)) {

--- a/csharp/source/autowrap/csharp/dlang.d
+++ b/csharp/source/autowrap/csharp/dlang.d
@@ -18,11 +18,10 @@ mixin(generateSharedTypes());
 
 // Wrap global functions from multiple modules
 public string wrapDLang(Modules...)() if(allSatisfy!(isModule, Modules)) {
-    import autowrap.csharp.common : getDLangInterfaceName;
+    import autowrap.csharp.common : isDateTimeType;
     import autowrap.reflection : AllAggregates;
     import std.traits : fullyQualifiedName, moduleName;
     import std.meta : AliasSeq;
-    import std.traits : ForeachType;
 
     string ret = string.init;
     ret ~= "import core.thread : thread_attachThis, thread_detachThis;" ~ newline;
@@ -117,16 +116,15 @@ private string generateConstructors(T)() {
 }
 
 private string generateMethods(T)() {
-    import autowrap.csharp.common : getDLangInterfaceName;
+    import autowrap.csharp.common : isDateTimeType, isDateTimeArrayType, getDLangInterfaceName;
     import std.traits : isFunction, fullyQualifiedName, ReturnType, Parameters, ParameterIdentifierTuple;
     import std.conv : to;
     import std.algorithm : among;
-    import std.traits : ForeachType;
 
     string ret = string.init;
     alias fqn = getDLangInterfaceType!T;
     foreach(m; __traits(allMembers, T)) {
-        if (m == "__ctor" || m == "toHash" || m == "opEquals" || m == "opCmp" || m == "factory") {
+        if (m.among("__ctor", "toHash", "opEquals", "opCmp", "factory")) {
             continue;
         }
 
@@ -335,9 +333,9 @@ private string generateMethodErrorHandling(string insideCode, string returnType)
 }
 
 private string generateParameter(T)(string name) {
+    import autowrap.csharp.common : isDateTimeType, isDateTimeArrayType;
     import std.datetime : DateTime, Date, TimeOfDay, SysTime, Duration;
     import std.traits : fullyQualifiedName;
-    import std.traits : ForeachType;
 
     alias fqn = fullyQualifiedName!(PrimordialType!T);
     static if (isDateTimeType!T) {
@@ -350,9 +348,9 @@ private string generateParameter(T)(string name) {
 }
 
 private string generateReturn(T)(string name) {
+    import autowrap.csharp.common : isDateTimeType, isDateTimeArrayType;
     import std.datetime : DateTime, Date, TimeOfDay, SysTime, Duration;
     import std.traits : fullyQualifiedName;
-    import std.traits : ForeachType;
 
     alias fqn = fullyQualifiedName!(PrimordialType!T);
     static if (isDateTimeType!T) {

--- a/csharp/source/autowrap/csharp/dlang.d
+++ b/csharp/source/autowrap/csharp/dlang.d
@@ -61,8 +61,7 @@ private string generateConstructors(T)() {
     alias fqn = getDLangInterfaceType!T;
 
     //Generate constructor methods
-    if (is(typeof(__traits(getMember, T, "__ctor")))) {
-    //static if(hasMember!(T, "__ctor") && __traits(getProtection, __traits(getMember, T, "__ctor")).among("export", "public")) {
+    static if(hasMember!(T, "__ctor") && __traits(getProtection, __traits(getMember, T, "__ctor")).among("export", "public")) {
         foreach(c; __traits(getOverloads, T, "__ctor")) {
             if (__traits(getProtection, c).among("export", "public")) {
                 alias paramNames = ParameterIdentifierTuple!c;

--- a/csharp/tests/Classes.cs
+++ b/csharp/tests/Classes.cs
@@ -2,6 +2,7 @@ namespace Autowrap.CSharp.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Test;
 
@@ -62,6 +63,65 @@ namespace Autowrap.CSharp.Tests
             Assert.AreEqual(2.0f, t.ValueMember.Value, "Incorrect Value for t.ValueMember");
             t.RefMember = new C1("Hello World!", 1);
             Assert.AreEqual(1, t.RefMember.IntValue, "Incorrect Value for t.RefMember.IntValue");
+        }
+
+        [TestMethod]
+        public void ClassSysDateTime() {
+            var t = new C1("Hello World!", 1);
+            var dt1 = new DateTime(2000, 1, 1, 0,0,0, DateTimeKind.Utc);
+            var dt2 = new DateTime(2000, 1, 1, 0,0,0, DateTimeKind.Utc);
+            var dt3 = new DateTime(2000, 1, 1, 0,0,0, DateTimeKind.Utc);
+            var dta = new DateTime[] {dt1, dt2, dt3};
+            var dto1 = new DateTimeOffset(dt1, new TimeSpan(0));
+            var dto2 = new DateTimeOffset(dt2, new TimeSpan(0));
+            var dto3 = new DateTimeOffset(dt3, new TimeSpan(0));
+            var dtoa = new DateTimeOffset[] {dto1, dto2, dto3};
+            var ts1 = new TimeSpan(1,0,0);
+            var ts2 = new TimeSpan(2,0,0);
+            var ts3 = new TimeSpan(3,0,0);
+            var ts4 = new TimeSpan(4,0,0);
+            var tsa = new TimeSpan[] {ts1, ts2, ts3, ts4};
+
+            t.DateMember = dt1;
+            Assert.AreEqual(dt1.Date, t.DateMember.Date, "Incorrect Value for t.DateMember");
+            t.DateArray = dta;
+            Assert.AreEqual(dta.Length, t.DateArray.Length, "Incorrect Length for t.DateArray");
+            Assert.AreEqual(dt1.Date, t.DateArray[0].Date, "Incorrect Value for t.DateArray[0]");
+            Assert.AreEqual(dt2.Date, t.DateArray[1].Date, "Incorrect Value for t.DateArray[1]");
+            Assert.AreEqual(dt3.Date, t.DateArray[2].Date, "Incorrect Value for t.DateArray[2]");
+
+            t.DateTimeMember = dt1;
+            Assert.AreEqual(dt1, t.DateTimeMember, "Incorrect Value for t.DateTimeMember");
+            t.DateTimeArray = dta;
+            Assert.AreEqual(dta.Length, t.DateTimeArray.Length, "Incorrect Length for t.DateTimeArray");
+            Assert.AreEqual(dt1, t.DateTimeArray[0], "Incorrect Value for t.DateTimeArray[0]");
+            Assert.AreEqual(dt2, t.DateTimeArray[1], "Incorrect Value for t.DateTimeArray[1]");
+            Assert.AreEqual(dt3, t.DateTimeArray[2], "Incorrect Value for t.DateTimeArray[2]");
+
+            t.TimeOfDayMember = dt1;
+            Assert.AreEqual(dt1.TimeOfDay, t.TimeOfDayMember.TimeOfDay, "Incorrect Value for t.TimeOfDayMember");
+            t.TimeOfDayArray = dta;
+            Assert.AreEqual(dta.Length, t.TimeOfDayArray.Length, "Incorrect Length for t.TimeOfDayArray");
+            Assert.AreEqual(dt1.TimeOfDay, t.TimeOfDayArray[0].TimeOfDay, "Incorrect Value for t.TimeOfDayArray[0]");
+            Assert.AreEqual(dt2.TimeOfDay, t.TimeOfDayArray[1].TimeOfDay, "Incorrect Value for t.TimeOfDayArray[1]");
+            Assert.AreEqual(dt3.TimeOfDay, t.TimeOfDayArray[2].TimeOfDay, "Incorrect Value for t.TimeOfDayArray[2]");
+
+            t.SysTimeMember = dto1;
+            Assert.AreEqual(dto1, t.SysTimeMember, "Incorrect Value for t.SysTimeMember");
+            t.SysTimeArray = dtoa;
+            Assert.AreEqual(dtoa.Length, t.SysTimeArray.Length, "Incorrect Length for t.SysTimeArray");
+            Assert.AreEqual(dto1, t.SysTimeArray[0], "Incorrect Value for t.SysTimeArray[0]");
+            Assert.AreEqual(dto2, t.SysTimeArray[1], "Incorrect Value for t.SysTimeArray[1]");
+            Assert.AreEqual(dto3, t.SysTimeArray[2], "Incorrect Value for t.SysTimeArray[2]");
+
+            t.DurationMember = ts1;
+            Assert.AreEqual(ts1, t.DurationMember, "Incorrect Value for t.DurationMember");
+            t.DurationArray = tsa;
+            Assert.AreEqual(tsa.Length, t.DurationArray.Length, "Incorrect Length for t.DurationArray");
+            Assert.AreEqual(ts1, t.DurationArray[0], "Incorrect Value for t.DurationArray[0]");
+            Assert.AreEqual(ts2, t.DurationArray[1], "Incorrect Value for t.DurationArray[1]");
+            Assert.AreEqual(ts3, t.DurationArray[2], "Incorrect Value for t.DurationArray[2]");
+            Assert.AreEqual(ts4, t.DurationArray[3], "Incorrect Value for t.DurationArray[3]");
         }
 
         [TestMethod]

--- a/csharp/tests/Functions.cs
+++ b/csharp/tests/Functions.cs
@@ -61,5 +61,32 @@ namespace Autowrap.CSharp.Tests
             Assert.AreEqual("No Error Thrown", errorResult, "Unexpected Result from TestErrorMessage.");
             Assert.ThrowsException<DLangException>(() => Test.Functions.TestErrorMessage(true));
         }
+
+        [TestMethod]
+        public void TestSysTimeArray() {
+            var date1 = new DateTimeOffset(1900,1,1,0,0,0,new TimeSpan(0,0,0));
+            var date2 = new DateTimeOffset(2000,1,1,0,0,0,new TimeSpan(-5,0,0));
+            var date3 = new DateTimeOffset(2000,12,31,0,0,0,new TimeSpan(-8,0,0));
+            var arr = new DateTimeOffset[] {date1, date2, date3};
+            var sysTimeArrayResult = Test.Functions.SystimeArrayTest(arr);
+            Assert.AreEqual(arr.Length, sysTimeArrayResult.Length, "Unexpected array length returned from SystimeArrayTest");
+            Assert.AreEqual(date1, sysTimeArrayResult[0], "Incorrect Value for sysTimeArrayResult[0]");
+            Assert.AreEqual(date2, sysTimeArrayResult[1], "Incorrect Value for sysTimeArrayResult[1]");
+            Assert.AreEqual(date3, sysTimeArrayResult[2], "Incorrect Value for sysTimeArrayResult[2]");
+        }
+
+        [TestMethod]
+        public void TestDateTime() {
+            var date = new DateTime(2000,12,31,0,0,0, DateTimeKind.Utc);
+            var datetimeResult = Test.Functions.DateTimeTest(date);
+            Assert.AreEqual(datetimeResult.Ticks, date.Ticks, "Incorrect Value for datetimeResult");
+        }
+
+        [TestMethod]
+        public void TestDuration() {
+            var duration = new TimeSpan(1,0,0,0,0);
+            var durationResult = Test.Functions.DurationTest(duration);
+            Assert.AreEqual(durationResult, duration, "Incorrect Value for durationResult");
+        }
     }
 }

--- a/csharp/tests/Wrapper.cs
+++ b/csharp/tests/Wrapper.cs
@@ -884,41 +884,41 @@ namespace Autowrap {
         internal static extern return_void_error Double_Set(slice dslice, IntPtr index, double value);
         [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DoubleAppendValue", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Double_AppendValue(slice dslice, double value);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeCreate", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeCreate", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Std_datetime_date_DateTime_Create(IntPtr capacity);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeSlice", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeSlice", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Std_datetime_date_DateTime_Slice(slice dslice, IntPtr begin, IntPtr end);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeAppendSlice", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeAppendSlice", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Std_datetime_date_DateTime_AppendSlice(slice dslice, slice array);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeGet", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeGet", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_datetime_error Std_datetime_date_DateTime_Get(slice dslice, IntPtr index);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeSet", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeSet", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_void_error Std_datetime_date_DateTime_Set(slice dslice, IntPtr index, datetime value);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeAppendValue", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeAppendValue", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Std_datetime_date_DateTime_AppendValue(slice dslice, datetime value);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeCreate", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeCreate", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Std_datetime_systime_SysTime_Create(IntPtr capacity);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeSlice", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeSlice", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Std_datetime_systime_SysTime_Slice(slice dslice, IntPtr begin, IntPtr end);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeAppendSlice", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeAppendSlice", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Std_datetime_systime_SysTime_AppendSlice(slice dslice, slice array);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeGet", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeGet", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_datetime_error Std_datetime_systime_SysTime_Get(slice dslice, IntPtr index);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeSet", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeSet", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_void_error Std_datetime_systime_SysTime_Set(slice dslice, IntPtr index, datetime value);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeAppendValue", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeAppendValue", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Std_datetime_systime_SysTime_AppendValue(slice dslice, datetime value);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeCreate", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeCreate", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Core_time_Duration_Create(IntPtr capacity);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeSlice", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeSlice", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Core_time_Duration_Slice(slice dslice, IntPtr begin, IntPtr end);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeAppendSlice", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeAppendSlice", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Core_time_Duration_AppendSlice(slice dslice, slice array);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeGet", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeGet", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_datetime_error Core_time_Duration_Get(slice dslice, IntPtr index);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeSet", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeSet", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_void_error Core_time_Duration_Set(slice dslice, IntPtr index, datetime value);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeAppendValue", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Autowrap_Csharp_Boilerplate_DatetimeAppendValue", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Core_time_Duration_AppendValue(slice dslice, datetime value);
         [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Test_S1Create", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Test_s1_Create(IntPtr capacity);

--- a/csharp/tests/Wrapper.cs
+++ b/csharp/tests/Wrapper.cs
@@ -357,6 +357,37 @@ namespace Autowrap {
 
     [GeneratedCodeAttribute("Autowrap", "1.0.0.0")]
     [StructLayout(LayoutKind.Sequential)]
+    internal struct datetime {
+        public datetime(long ticks, long offset) {
+            this._ticks = ticks;
+            this._offset = offset;
+        }
+        public static implicit operator datetime(DateTime ret) { return new datetime(ret.Ticks, 0L); }
+        public static implicit operator datetime(DateTimeOffset ret) { return new datetime(ret.Ticks, ret.Offset.Ticks); }
+        public static implicit operator datetime(TimeSpan ret) { return new datetime(ret.Ticks, 0L); }
+        public static implicit operator DateTime(datetime ret) { return new DateTime(ret._ticks, DateTimeKind.Unspecified); }
+        public static implicit operator DateTimeOffset(datetime ret) { return new DateTimeOffset(ret._ticks, new TimeSpan(ret._offset)); }
+        public static implicit operator TimeSpan(datetime ret) { return new TimeSpan(ret._ticks); }
+        private long _ticks;
+        private long _offset;
+    }
+
+    [GeneratedCodeAttribute("Autowrap", "1.0.0.0")]
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct return_datetime_error {
+        private void EnsureValid() {
+            var errStr = SharedFunctions.SliceToString(_error, DStringType._wstring);
+            if (!string.IsNullOrEmpty(errStr)) throw new DLangException(errStr);
+        }
+        public static implicit operator DateTime(return_datetime_error ret) { ret.EnsureValid(); return ret._value; }
+        public static implicit operator DateTimeOffset(return_datetime_error ret) { ret.EnsureValid(); return ret._value; }
+        public static implicit operator TimeSpan(return_datetime_error ret) { ret.EnsureValid(); return ret._value; }
+        private datetime _value;
+        private slice _error;
+    }
+
+    [GeneratedCodeAttribute("Autowrap", "1.0.0.0")]
+    [StructLayout(LayoutKind.Sequential)]
     internal struct return_byte_error {
         private void EnsureValid() {
             var errStr = SharedFunctions.SliceToString(_error, DStringType._wstring);
@@ -773,6 +804,42 @@ namespace Autowrap {
         internal static extern return_void_error Double_Set(slice dslice, IntPtr index, double value);
         [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DoubleAppendValue", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Double_AppendValue(slice dslice, double value);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Date_DateTimeCreate", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_slice_error Std_datetime_date_DateTime_Create(IntPtr capacity);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Date_DateTimeSlice", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_slice_error Std_datetime_date_DateTime_Slice(slice dslice, IntPtr begin, IntPtr end);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Date_DateTimeAppendSlice", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_slice_error Std_datetime_date_DateTime_AppendSlice(slice dslice, slice array);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Date_DateTimeGet", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_datetime_error Std_datetime_date_DateTime_Get(slice dslice, IntPtr index);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Date_DateTimeSet", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_void_error Std_datetime_date_DateTime_Set(slice dslice, IntPtr index, datetime value);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Date_DateTimeAppendValue", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_slice_error Std_datetime_date_DateTime_AppendValue(slice dslice, datetime value);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Systime_SysTimeCreate", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_slice_error Std_datetime_systime_SysTime_Create(IntPtr capacity);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Systime_SysTimeSlice", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_slice_error Std_datetime_systime_SysTime_Slice(slice dslice, IntPtr begin, IntPtr end);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Systime_SysTimeAppendSlice", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_slice_error Std_datetime_systime_SysTime_AppendSlice(slice dslice, slice array);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Systime_SysTimeGet", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_datetime_error Std_datetime_systime_SysTime_Get(slice dslice, IntPtr index);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Systime_SysTimeSet", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_void_error Std_datetime_systime_SysTime_Set(slice dslice, IntPtr index, datetime value);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Systime_SysTimeAppendValue", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_slice_error Std_datetime_systime_SysTime_AppendValue(slice dslice, datetime value);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Core_Time_DurationCreate", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_slice_error Core_time_Duration_Create(IntPtr capacity);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Core_Time_DurationSlice", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_slice_error Core_time_Duration_Slice(slice dslice, IntPtr begin, IntPtr end);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Core_Time_DurationAppendSlice", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_slice_error Core_time_Duration_AppendSlice(slice dslice, slice array);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Core_Time_DurationGet", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_datetime_error Core_time_Duration_Get(slice dslice, IntPtr index);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Core_Time_DurationSet", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_void_error Core_time_Duration_Set(slice dslice, IntPtr index, datetime value);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Core_Time_DurationAppendValue", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern return_slice_error Core_time_Duration_AppendValue(slice dslice, datetime value);
         [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Test_S1Create", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Test_s1_Create(IntPtr capacity);
         [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Test_S1Slice", CallingConvention = CallingConvention.Cdecl)]
@@ -883,6 +950,9 @@ namespace Autowrap {
             else if (typeof(T) == typeof(ulong)) this._slice = RangeFunctions.Ulong_Create(new IntPtr(capacity));
             else if (typeof(T) == typeof(float)) this._slice = RangeFunctions.Float_Create(new IntPtr(capacity));
             else if (typeof(T) == typeof(double)) this._slice = RangeFunctions.Double_Create(new IntPtr(capacity));
+            else if (typeof(T) == typeof(DateTime)) this._slice = RangeFunctions.Std_datetime_date_DateTime_Create(new IntPtr(capacity));
+            else if (typeof(T) == typeof(DateTimeOffset)) this._slice = RangeFunctions.Std_datetime_systime_SysTime_Create(new IntPtr(capacity));
+            else if (typeof(T) == typeof(TimeSpan)) this._slice = RangeFunctions.Core_time_Duration_Create(new IntPtr(capacity));
             else if (typeof(T) == typeof(Test.S1)) this._slice = RangeFunctions.Test_s1_Create(new IntPtr(capacity));
             else if (typeof(T) == typeof(Test.S2)) this._slice = RangeFunctions.Test_s2_Create(new IntPtr(capacity));
             else if (typeof(T) == typeof(Test.C1)) this._slice = RangeFunctions.Test_c1_Create(new IntPtr(capacity));
@@ -910,6 +980,9 @@ namespace Autowrap {
                 else if (typeof(T) == typeof(ulong)) return (T)(object)(ulong)RangeFunctions.Ulong_Get(_slice, new IntPtr(i));
                 else if (typeof(T) == typeof(float)) return (T)(object)(float)RangeFunctions.Float_Get(_slice, new IntPtr(i));
                 else if (typeof(T) == typeof(double)) return (T)(object)(double)RangeFunctions.Double_Get(_slice, new IntPtr(i));
+                else if (typeof(T) == typeof(DateTime)) return (T)(object)(DateTime)RangeFunctions.Std_datetime_date_DateTime_Get(_slice, new IntPtr(i));
+                else if (typeof(T) == typeof(DateTimeOffset)) return (T)(object)(DateTimeOffset)RangeFunctions.Std_datetime_systime_SysTime_Get(_slice, new IntPtr(i));
+                else if (typeof(T) == typeof(TimeSpan)) return (T)(object)(TimeSpan)RangeFunctions.Core_time_Duration_Get(_slice, new IntPtr(i));
                 else if (typeof(T) == typeof(Test.S1)) return (T)(object)(Test.S1)RangeFunctions.Test_s1_Get(_slice, new IntPtr(i));
                 else if (typeof(T) == typeof(Test.S2)) return (T)(object)(Test.S2)RangeFunctions.Test_s2_Get(_slice, new IntPtr(i));
                 else if (typeof(T) == typeof(Test.C1)) return (T)(object)new Test.C1(RangeFunctions.Test_c1_Get(_slice, new IntPtr(i)));
@@ -932,6 +1005,9 @@ namespace Autowrap {
                 else if (typeof(T) == typeof(ulong)) RangeFunctions.Ulong_Set(_slice, new IntPtr(i), (ulong)(object)value);
                 else if (typeof(T) == typeof(float)) RangeFunctions.Float_Set(_slice, new IntPtr(i), (float)(object)value);
                 else if (typeof(T) == typeof(double)) RangeFunctions.Double_Set(_slice, new IntPtr(i), (double)(object)value);
+                else if (typeof(T) == typeof(DateTime)) RangeFunctions.Std_datetime_date_DateTime_Set(_slice, new IntPtr(i), (DateTime)(object)value);
+                else if (typeof(T) == typeof(DateTimeOffset)) RangeFunctions.Std_datetime_systime_SysTime_Set(_slice, new IntPtr(i), (DateTimeOffset)(object)value);
+                else if (typeof(T) == typeof(TimeSpan)) RangeFunctions.Core_time_Duration_Set(_slice, new IntPtr(i), (TimeSpan)(object)value);
                 else if (typeof(T) == typeof(Test.S1)) RangeFunctions.Test_s1_Set(_slice, new IntPtr(i), (Test.S1)(object)value);
                 else if (typeof(T) == typeof(Test.S2)) RangeFunctions.Test_s2_Set(_slice, new IntPtr(i), (Test.S2)(object)value);
                 else if (typeof(T) == typeof(Test.C1)) RangeFunctions.Test_c1_Set(_slice, new IntPtr(i), (Test.C1)(object)value);
@@ -954,6 +1030,9 @@ namespace Autowrap {
             else if (typeof(T) == typeof(ulong)) return new Range<T>(RangeFunctions.Ulong_Slice(_slice, new IntPtr(begin), _slice.length), DStringType.None);
             else if (typeof(T) == typeof(float)) return new Range<T>(RangeFunctions.Float_Slice(_slice, new IntPtr(begin), _slice.length), DStringType.None);
             else if (typeof(T) == typeof(double)) return new Range<T>(RangeFunctions.Double_Slice(_slice, new IntPtr(begin), _slice.length), DStringType.None);
+            else if (typeof(T) == typeof(DateTime)) return new Range<T>(RangeFunctions.Std_datetime_date_DateTime_Slice(_slice, new IntPtr(begin), _slice.length), DStringType.None);
+            else if (typeof(T) == typeof(DateTimeOffset)) return new Range<T>(RangeFunctions.Std_datetime_systime_SysTime_Slice(_slice, new IntPtr(begin), _slice.length), DStringType.None);
+            else if (typeof(T) == typeof(TimeSpan)) return new Range<T>(RangeFunctions.Core_time_Duration_Slice(_slice, new IntPtr(begin), _slice.length), DStringType.None);
             else if (typeof(T) == typeof(Test.S1)) return new Range<T>(RangeFunctions.Test_s1_Slice(_slice, new IntPtr(begin), _slice.length), DStringType.None);
             else if (typeof(T) == typeof(Test.S2)) return new Range<T>(RangeFunctions.Test_s2_Slice(_slice, new IntPtr(begin), _slice.length), DStringType.None);
             else if (typeof(T) == typeof(Test.C1)) return new Range<T>(RangeFunctions.Test_c1_Slice(_slice, new IntPtr(begin), _slice.length), DStringType.None);
@@ -979,6 +1058,9 @@ namespace Autowrap {
             else if (typeof(T) == typeof(ulong)) return new Range<T>(RangeFunctions.Ulong_Slice(_slice, new IntPtr(begin), new IntPtr(end)), DStringType.None);
             else if (typeof(T) == typeof(float)) return new Range<T>(RangeFunctions.Float_Slice(_slice, new IntPtr(begin), new IntPtr(end)), DStringType.None);
             else if (typeof(T) == typeof(double)) return new Range<T>(RangeFunctions.Double_Slice(_slice, new IntPtr(begin), new IntPtr(end)), DStringType.None);
+            else if (typeof(T) == typeof(DateTime)) return new Range<T>(RangeFunctions.Std_datetime_date_DateTime_Slice(_slice, new IntPtr(begin), new IntPtr(end)), DStringType.None);
+            else if (typeof(T) == typeof(DateTimeOffset)) return new Range<T>(RangeFunctions.Std_datetime_systime_SysTime_Slice(_slice, new IntPtr(begin), new IntPtr(end)), DStringType.None);
+            else if (typeof(T) == typeof(TimeSpan)) return new Range<T>(RangeFunctions.Core_time_Duration_Slice(_slice, new IntPtr(begin), new IntPtr(end)), DStringType.None);
             else if (typeof(T) == typeof(Test.S1)) return new Range<T>(RangeFunctions.Test_s1_Slice(_slice, new IntPtr(begin), new IntPtr(end)), DStringType.None);
             else if (typeof(T) == typeof(Test.S2)) return new Range<T>(RangeFunctions.Test_s2_Slice(_slice, new IntPtr(begin), new IntPtr(end)), DStringType.None);
             else if (typeof(T) == typeof(Test.C1)) return new Range<T>(RangeFunctions.Test_c1_Slice(_slice, new IntPtr(begin), new IntPtr(end)), DStringType.None);
@@ -1001,6 +1083,9 @@ namespace Autowrap {
             else if (typeof(T) == typeof(ulong)) { this._slice = RangeFunctions.Ulong_AppendValue(this._slice, (ulong)(object)value); }
             else if (typeof(T) == typeof(float)) { this._slice = RangeFunctions.Float_AppendValue(this._slice, (float)(object)value); }
             else if (typeof(T) == typeof(double)) { this._slice = RangeFunctions.Double_AppendValue(this._slice, (double)(object)value); }
+            else if (typeof(T) == typeof(DateTime)) { this._slice = RangeFunctions.Std_datetime_date_DateTime_AppendValue(this._slice, (DateTime)(object)value); }
+            else if (typeof(T) == typeof(DateTimeOffset)) { this._slice = RangeFunctions.Std_datetime_systime_SysTime_AppendValue(this._slice, (DateTimeOffset)(object)value); }
+            else if (typeof(T) == typeof(TimeSpan)) { this._slice = RangeFunctions.Core_time_Duration_AppendValue(this._slice, (TimeSpan)(object)value); }
             else if (typeof(T) == typeof(Test.S1)) { this._slice = RangeFunctions.Test_s1_AppendValue(this._slice, (Test.S1)(object)value); }
             else if (typeof(T) == typeof(Test.S2)) { this._slice = RangeFunctions.Test_s2_AppendValue(this._slice, (Test.S2)(object)value); }
             else if (typeof(T) == typeof(Test.C1)) { this._slice = RangeFunctions.Test_c1_AppendValue(this._slice, (Test.C1)(object)value); }
@@ -1027,6 +1112,9 @@ namespace Autowrap {
             else if (typeof(T) == typeof(ulong)) { range._slice = RangeFunctions.Ulong_AppendSlice(range._slice, source._slice); return range; }
             else if (typeof(T) == typeof(float)) { range._slice = RangeFunctions.Float_AppendSlice(range._slice, source._slice); return range; }
             else if (typeof(T) == typeof(double)) { range._slice = RangeFunctions.Double_AppendSlice(range._slice, source._slice); return range; }
+            else if (typeof(T) == typeof(DateTime)) { range._slice = RangeFunctions.Std_datetime_date_DateTime_AppendSlice(range._slice, source._slice); return range; }
+            else if (typeof(T) == typeof(DateTimeOffset)) { range._slice = RangeFunctions.Std_datetime_systime_SysTime_AppendSlice(range._slice, source._slice); return range; }
+            else if (typeof(T) == typeof(TimeSpan)) { range._slice = RangeFunctions.Core_time_Duration_AppendSlice(range._slice, source._slice); return range; }
             else if (typeof(T) == typeof(Test.S1)) { range._slice = RangeFunctions.Test_s1_AppendSlice(range._slice, source._slice); return range; }
             else if (typeof(T) == typeof(Test.S2)) { range._slice = RangeFunctions.Test_s2_AppendSlice(range._slice, source._slice); return range; }
             else if (typeof(T) == typeof(Test.C1)) { range._slice = RangeFunctions.Test_c1_AppendSlice(range._slice, source._slice); return range; }
@@ -1050,6 +1138,9 @@ namespace Autowrap {
                 else if (typeof(T) == typeof(ulong)) yield return (T)(object)(ulong)RangeFunctions.Ulong_Get(_slice, new IntPtr(i));
                 else if (typeof(T) == typeof(float)) yield return (T)(object)(float)RangeFunctions.Float_Get(_slice, new IntPtr(i));
                 else if (typeof(T) == typeof(double)) yield return (T)(object)(double)RangeFunctions.Double_Get(_slice, new IntPtr(i));
+                else if (typeof(T) == typeof(DateTime)) yield return (T)(object)(DateTime)RangeFunctions.Std_datetime_date_DateTime_Get(_slice, new IntPtr(i));
+                else if (typeof(T) == typeof(DateTimeOffset)) yield return (T)(object)(DateTimeOffset)RangeFunctions.Std_datetime_systime_SysTime_Get(_slice, new IntPtr(i));
+                else if (typeof(T) == typeof(TimeSpan)) yield return (T)(object)(TimeSpan)RangeFunctions.Core_time_Duration_Get(_slice, new IntPtr(i));
                 else if (typeof(T) == typeof(Test.S1)) yield return (T)(object)(Test.S1)RangeFunctions.Test_s1_Get(_slice, new IntPtr(i));
                 else if (typeof(T) == typeof(Test.S2)) yield return (T)(object)(Test.S2)RangeFunctions.Test_s2_Get(_slice, new IntPtr(i));
                 else if (typeof(T) == typeof(Test.C1)) yield return (T)(object)new Test.C1(RangeFunctions.Test_c1_Get(_slice, new IntPtr(i)));

--- a/csharp/tests/Wrapper.cs
+++ b/csharp/tests/Wrapper.cs
@@ -57,6 +57,27 @@ namespace Test {
             var dlang_ret = dlang_TestStringRanges(arr.ToSlice());
             return new Range<string>(dlang_ret, DStringType._string);
         }
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_TestSystimeArrayTest", CallingConvention = CallingConvention.Cdecl)]
+
+        private static extern return_slice_error dlang_SystimeArrayTest(slice array);
+        public static Range<DateTimeOffset> SystimeArrayTest(Range<DateTimeOffset> array) {
+            var dlang_ret = dlang_SystimeArrayTest(array.ToSlice());
+            return new Range<DateTimeOffset>(dlang_ret, DStringType.None);
+        }
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_TestDurationTest", CallingConvention = CallingConvention.Cdecl)]
+
+        private static extern return_datetime_error dlang_DurationTest(datetime value);
+        public static TimeSpan DurationTest(TimeSpan value) {
+            var dlang_ret = dlang_DurationTest(value);
+            return dlang_ret;
+        }
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_TestDateTimeTest", CallingConvention = CallingConvention.Cdecl)]
+
+        private static extern return_datetime_error dlang_DateTimeTest(datetime value);
+        public static DateTime DateTimeTest(DateTime value) {
+            var dlang_ret = dlang_DateTimeTest(value);
+            return dlang_ret;
+        }
 
     }
 
@@ -146,6 +167,14 @@ namespace Test {
         private static extern return_slice_error dlang_C1_RefSliceProperty(IntPtr __obj__);
         [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1RefSliceProperty1", CallingConvention = CallingConvention.Cdecl)]
         private static extern return_slice_error dlang_C1_RefSliceProperty(IntPtr __obj__, slice value);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1SysTimeProperty0", CallingConvention = CallingConvention.Cdecl)]
+        private static extern return_datetime_error dlang_C1_SysTimeProperty(IntPtr __obj__);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1SysTimeProperty1", CallingConvention = CallingConvention.Cdecl)]
+        private static extern return_datetime_error dlang_C1_SysTimeProperty(IntPtr __obj__, datetime value);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1SysTimeSliceProperty0", CallingConvention = CallingConvention.Cdecl)]
+        private static extern return_slice_error dlang_C1_SysTimeSliceProperty(IntPtr __obj__);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1SysTimeSliceProperty1", CallingConvention = CallingConvention.Cdecl)]
+        private static extern return_slice_error dlang_C1_SysTimeSliceProperty(IntPtr __obj__, slice value);
         [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1TestMemberFunction0", CallingConvention = CallingConvention.Cdecl)]
         private static extern return_slice_error dlang_C1_TestMemberFunction(IntPtr __obj__, slice test, Test.S1 value);
         public string TestMemberFunction(string test, Test.S1 value) {
@@ -169,6 +198,8 @@ namespace Test {
         public Range<string> DstringSliceProperty { get => new Range<string>(dlang_C1_DstringSliceProperty(this), DStringType._dstring); set => dlang_C1_DstringSliceProperty(this, value.ToSlice(DStringType._dstring)); }
         public Range<Test.S1> StructSliceProperty { get => new Range<Test.S1>(dlang_C1_StructSliceProperty(this), DStringType.None); set => dlang_C1_StructSliceProperty(this, value.ToSlice()); }
         public Range<Test.C1> RefSliceProperty { get => new Range<Test.C1>(dlang_C1_RefSliceProperty(this), DStringType.None); set => dlang_C1_RefSliceProperty(this, value.ToSlice()); }
+        public DateTimeOffset SysTimeProperty { get => dlang_C1_SysTimeProperty(this); set => dlang_C1_SysTimeProperty(this, value); }
+        public Range<DateTimeOffset> SysTimeSliceProperty { get => new Range<DateTimeOffset>(dlang_C1_SysTimeSliceProperty(this), DStringType.None); set => dlang_C1_SysTimeSliceProperty(this, value.ToSlice()); }
         [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1IntValue_get", CallingConvention = CallingConvention.Cdecl)]
         private static extern return_int_error dlang_intValue_get(IntPtr ptr);
         [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1IntValue_set", CallingConvention = CallingConvention.Cdecl)]
@@ -264,6 +295,56 @@ namespace Test {
         [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1StructArray_set", CallingConvention = CallingConvention.Cdecl)]
         private static extern void dlang_structArray_set(IntPtr ptr, slice value);
         public Range<Test.S1> StructArray { get => new Range<Test.S1>(dlang_structArray_get(this), DStringType.None); set => dlang_structArray_set(this, value.ToSlice()); }
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1DurationMember_get", CallingConvention = CallingConvention.Cdecl)]
+        private static extern return_datetime_error dlang_durationMember_get(IntPtr ptr);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1DurationMember_set", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void dlang_durationMember_set(IntPtr ptr, datetime value);
+        public TimeSpan DurationMember { get => dlang_durationMember_get(this); set => dlang_durationMember_set(this, value); }
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1DateMember_get", CallingConvention = CallingConvention.Cdecl)]
+        private static extern return_datetime_error dlang_dateMember_get(IntPtr ptr);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1DateMember_set", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void dlang_dateMember_set(IntPtr ptr, datetime value);
+        public DateTime DateMember { get => dlang_dateMember_get(this); set => dlang_dateMember_set(this, value); }
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1DateTimeMember_get", CallingConvention = CallingConvention.Cdecl)]
+        private static extern return_datetime_error dlang_dateTimeMember_get(IntPtr ptr);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1DateTimeMember_set", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void dlang_dateTimeMember_set(IntPtr ptr, datetime value);
+        public DateTime DateTimeMember { get => dlang_dateTimeMember_get(this); set => dlang_dateTimeMember_set(this, value); }
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1SysTimeMember_get", CallingConvention = CallingConvention.Cdecl)]
+        private static extern return_datetime_error dlang_sysTimeMember_get(IntPtr ptr);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1SysTimeMember_set", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void dlang_sysTimeMember_set(IntPtr ptr, datetime value);
+        public DateTimeOffset SysTimeMember { get => dlang_sysTimeMember_get(this); set => dlang_sysTimeMember_set(this, value); }
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1TimeOfDayMember_get", CallingConvention = CallingConvention.Cdecl)]
+        private static extern return_datetime_error dlang_timeOfDayMember_get(IntPtr ptr);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1TimeOfDayMember_set", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void dlang_timeOfDayMember_set(IntPtr ptr, datetime value);
+        public DateTime TimeOfDayMember { get => dlang_timeOfDayMember_get(this); set => dlang_timeOfDayMember_set(this, value); }
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1DurationArray_get", CallingConvention = CallingConvention.Cdecl)]
+        private static extern return_slice_error dlang_durationArray_get(IntPtr ptr);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1DurationArray_set", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void dlang_durationArray_set(IntPtr ptr, slice value);
+        public Range<TimeSpan> DurationArray { get => new Range<TimeSpan>(dlang_durationArray_get(this), DStringType.None); set => dlang_durationArray_set(this, value.ToSlice()); }
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1DateArray_get", CallingConvention = CallingConvention.Cdecl)]
+        private static extern return_slice_error dlang_dateArray_get(IntPtr ptr);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1DateArray_set", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void dlang_dateArray_set(IntPtr ptr, slice value);
+        public Range<DateTime> DateArray { get => new Range<DateTime>(dlang_dateArray_get(this), DStringType.None); set => dlang_dateArray_set(this, value.ToSlice()); }
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1DateTimeArray_get", CallingConvention = CallingConvention.Cdecl)]
+        private static extern return_slice_error dlang_dateTimeArray_get(IntPtr ptr);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1DateTimeArray_set", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void dlang_dateTimeArray_set(IntPtr ptr, slice value);
+        public Range<DateTime> DateTimeArray { get => new Range<DateTime>(dlang_dateTimeArray_get(this), DStringType.None); set => dlang_dateTimeArray_set(this, value.ToSlice()); }
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1SysTimeArray_get", CallingConvention = CallingConvention.Cdecl)]
+        private static extern return_slice_error dlang_sysTimeArray_get(IntPtr ptr);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1SysTimeArray_set", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void dlang_sysTimeArray_set(IntPtr ptr, slice value);
+        public Range<DateTimeOffset> SysTimeArray { get => new Range<DateTimeOffset>(dlang_sysTimeArray_get(this), DStringType.None); set => dlang_sysTimeArray_set(this, value.ToSlice()); }
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1TimeOfDayArray_get", CallingConvention = CallingConvention.Cdecl)]
+        private static extern return_slice_error dlang_timeOfDayArray_get(IntPtr ptr);
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_Test_C1TimeOfDayArray_set", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void dlang_timeOfDayArray_set(IntPtr ptr, slice value);
+        public Range<DateTime> TimeOfDayArray { get => new Range<DateTime>(dlang_timeOfDayArray_get(this), DStringType.None); set => dlang_timeOfDayArray_set(this, value.ToSlice()); }
     }
 
 }
@@ -365,7 +446,7 @@ namespace Autowrap {
         public static implicit operator datetime(DateTime ret) { return new datetime(ret.Ticks, 0L); }
         public static implicit operator datetime(DateTimeOffset ret) { return new datetime(ret.Ticks, ret.Offset.Ticks); }
         public static implicit operator datetime(TimeSpan ret) { return new datetime(ret.Ticks, 0L); }
-        public static implicit operator DateTime(datetime ret) { return new DateTime(ret._ticks, DateTimeKind.Unspecified); }
+        public static implicit operator DateTime(datetime ret) { return new DateTime(ret._ticks, DateTimeKind.Local); }
         public static implicit operator DateTimeOffset(datetime ret) { return new DateTimeOffset(ret._ticks, new TimeSpan(ret._offset)); }
         public static implicit operator TimeSpan(datetime ret) { return new TimeSpan(ret._ticks); }
         private long _ticks;
@@ -559,7 +640,6 @@ namespace Autowrap {
         static SharedFunctions() {
             Stream stream = null;
             var outputName = Path.Combine(Environment.CurrentDirectory, RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "libcsharp-tests.dylib" : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "libcsharp-tests.so" : "csharp-tests.dll");
-            Console.WriteLine($"Library Path: {outputName}");
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
                 stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Autowrap.CSharp.Tests.libcsharp-tests.dylib");
@@ -804,41 +884,41 @@ namespace Autowrap {
         internal static extern return_void_error Double_Set(slice dslice, IntPtr index, double value);
         [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DoubleAppendValue", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Double_AppendValue(slice dslice, double value);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Date_DateTimeCreate", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeCreate", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Std_datetime_date_DateTime_Create(IntPtr capacity);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Date_DateTimeSlice", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeSlice", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Std_datetime_date_DateTime_Slice(slice dslice, IntPtr begin, IntPtr end);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Date_DateTimeAppendSlice", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeAppendSlice", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Std_datetime_date_DateTime_AppendSlice(slice dslice, slice array);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Date_DateTimeGet", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeGet", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_datetime_error Std_datetime_date_DateTime_Get(slice dslice, IntPtr index);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Date_DateTimeSet", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeSet", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_void_error Std_datetime_date_DateTime_Set(slice dslice, IntPtr index, datetime value);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Date_DateTimeAppendValue", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeAppendValue", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Std_datetime_date_DateTime_AppendValue(slice dslice, datetime value);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Systime_SysTimeCreate", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeCreate", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Std_datetime_systime_SysTime_Create(IntPtr capacity);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Systime_SysTimeSlice", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeSlice", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Std_datetime_systime_SysTime_Slice(slice dslice, IntPtr begin, IntPtr end);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Systime_SysTimeAppendSlice", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeAppendSlice", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Std_datetime_systime_SysTime_AppendSlice(slice dslice, slice array);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Systime_SysTimeGet", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeGet", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_datetime_error Std_datetime_systime_SysTime_Get(slice dslice, IntPtr index);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Systime_SysTimeSet", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeSet", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_void_error Std_datetime_systime_SysTime_Set(slice dslice, IntPtr index, datetime value);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Std_Datetime_Systime_SysTimeAppendValue", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeAppendValue", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Std_datetime_systime_SysTime_AppendValue(slice dslice, datetime value);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Core_Time_DurationCreate", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeCreate", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Core_time_Duration_Create(IntPtr capacity);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Core_Time_DurationSlice", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeSlice", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Core_time_Duration_Slice(slice dslice, IntPtr begin, IntPtr end);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Core_Time_DurationAppendSlice", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeAppendSlice", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Core_time_Duration_AppendSlice(slice dslice, slice array);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Core_Time_DurationGet", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeGet", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_datetime_error Core_time_Duration_Get(slice dslice, IntPtr index);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Core_Time_DurationSet", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeSet", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_void_error Core_time_Duration_Set(slice dslice, IntPtr index, datetime value);
-        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Core_Time_DurationAppendValue", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_DatetimeAppendValue", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Core_time_Duration_AppendValue(slice dslice, datetime value);
         [DllImport("csharp-tests", EntryPoint = "autowrap_csharp_slice_Test_S1Create", CallingConvention = CallingConvention.Cdecl)]
         internal static extern return_slice_error Test_s1_Create(IntPtr capacity);

--- a/csharp/tests/source/app.d
+++ b/csharp/tests/source/app.d
@@ -13,3 +13,5 @@ mixin(
         RootNamespace("Autowrap.CSharp.Tests")
     )
 );
+
+pragma(msg, wrapCSharp(modules, OutputFileName("Wrapper.cs"), LibraryName("csharp-tests"), RootNamespace("Autowrap.CSharp.Tests")));

--- a/csharp/tests/source/app.d
+++ b/csharp/tests/source/app.d
@@ -14,4 +14,4 @@ mixin(
     )
 );
 
-pragma(msg, wrapDLang!(Module("test")));
+//pragma(msg, wrapDLang!(Module("test"))); //Uncomment this to see generated D interface code.

--- a/csharp/tests/source/app.d
+++ b/csharp/tests/source/app.d
@@ -14,4 +14,4 @@ mixin(
     )
 );
 
-pragma(msg, wrapCSharp(modules, OutputFileName("Wrapper.cs"), LibraryName("csharp-tests"), RootNamespace("Autowrap.CSharp.Tests")));
+pragma(msg, wrapDLang!(Module("test")));

--- a/csharp/tests/source/test.d
+++ b/csharp/tests/source/test.d
@@ -1,5 +1,8 @@
 module test;
 
+import core.time : Duration;
+import std.datetime : Date, DateTime, SysTime, TimeOfDay;
+
 export string parameterlessFunction() {
     return "Parameterless Function";
 }
@@ -93,6 +96,16 @@ class c1 {
     public c1 refMember;
     public c1[] refArray;
     public s1[] structArray;
+    public Duration durationMember;
+    public Date dateMember;
+    public DateTime dateTimeMember;
+    public SysTime sysTimeMember;
+    public TimeOfDay timeOfDayMember;
+    public Duration[] durationArray;
+    public Date[] dateArray;
+    public DateTime[] dateTimeArray;
+    public SysTime[] sysTimeArray;
+    public TimeOfDay[] timeOfDayArray;    
 
     //Property test cases
     private s2 _structProperty;
@@ -165,6 +178,22 @@ class c1 {
     }
     public @property c1[] refSliceProperty(c1[] value) {
         return _refSliceProperty = value;
+    }
+
+    private SysTime _sysTimeProperty;
+    public @property SysTime sysTimeProperty() {
+        return _sysTimeProperty;
+    }
+    public @property SysTime sysTimeProperty(SysTime value) {
+        return _sysTimeProperty = value;
+    }
+
+    private SysTime[] _sysTimeSliceProperty;
+    public @property SysTime[] sysTimeSliceProperty() {
+        return _sysTimeSliceProperty;
+    }
+    public @property SysTime[] sysTimeSliceProperty(SysTime[] value) {
+        return _sysTimeSliceProperty = value;
     }
 
     public string testMemberFunction(string test, s1 value){

--- a/csharp/tests/source/test.d
+++ b/csharp/tests/source/test.d
@@ -39,6 +39,18 @@ export string[] testStringRanges(dstring[] arr) {
     return temp;
 }
 
+export SysTime[] systimeArrayTest(SysTime[] array) {
+    return array.dup;
+}
+
+export Duration durationTest(Duration value) {
+    return value;
+}
+
+export DateTime dateTimeTest(DateTime value) {
+    return value;
+}
+
 struct s1 {
     public float value;
     public s2 nestedStruct;
@@ -105,7 +117,7 @@ class c1 {
     public Date[] dateArray;
     public DateTime[] dateTimeArray;
     public SysTime[] sysTimeArray;
-    public TimeOfDay[] timeOfDayArray;    
+    public TimeOfDay[] timeOfDayArray;
 
     //Property test cases
     private s2 _structProperty;

--- a/reflection/source/autowrap/reflection.d
+++ b/reflection/source/autowrap/reflection.d
@@ -281,7 +281,7 @@ package template Symbol(alias parent, string memberName) {
 
 
 // T -> T, T[] -> T, T[][] -> T, T* -> T
-private template PrimordialType(T) if(isArray!T) {
+template PrimordialType(T) if(isArray!T) {
 
     import std.range.primitives: ElementType;
 
@@ -293,7 +293,7 @@ private template PrimordialType(T) if(isArray!T) {
 
 
 // T -> T, T[] -> T, T[][] -> T, T* -> T
-private template PrimordialType(T) if(!isArray!T) {
+template PrimordialType(T) if(!isArray!T) {
 
     import std.traits: isPointer, PointerTarget;
 


### PR DESCRIPTION
This PR adds support for the D Date/Time types (TimeOfDay, Date, DateTime, SysTime, and Duration) to the C# wrapper generator. NOTE: This PR does NOT add support for public struct fields containing Date/Time types. This is due to the need to implement special handling that ensures that the struct memory layout is retained due to the fact that the memory layout of the intermediate type does not match any of the Date/Time types in either language and as such cannot be used in place of those types. The solution will be to implement opaque types that have matching memory sizes. But this is a specialized concern and this PR is big enough as it is.